### PR TITLE
Force wake-up UserGroupInformation to avoid dead-lock.

### DIFF
--- a/bridge/pom.xml
+++ b/bridge/pom.xml
@@ -17,5 +17,6 @@
     <module>client</module>
     <module>custom</module>
     <module>assembly</module>
+    <module>workaround/hadoop</module>
   </modules>
 </project>

--- a/bridge/workaround/hadoop/.gitignore
+++ b/bridge/workaround/hadoop/.gitignore
@@ -1,0 +1,5 @@
+/target
+/.project
+/.classpath
+/.settings
+/bin

--- a/bridge/workaround/hadoop/pom.xml
+++ b/bridge/workaround/hadoop/pom.xml
@@ -1,0 +1,44 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<project xmlns="http://maven.apache.org/POM/4.0.0" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 http://maven.apache.org/xsd/maven-4.0.0.xsd">
+  <modelVersion>4.0.0</modelVersion>
+  <name>Hadoop workaround for Asakusa on M3BP</name>
+  <artifactId>asakusa-m3bp-workaround-hadoop</artifactId>
+  <parent>
+    <artifactId>project</artifactId>
+    <groupId>com.asakusafw.m3bp.bridge</groupId>
+    <version>0.1.1-SNAPSHOT</version>
+    <relativePath>../..</relativePath>
+  </parent>
+
+  <packaging>jar</packaging>
+
+  <dependencies>
+    <dependency>
+      <groupId>com.asakusafw.dag.runtime</groupId>
+      <artifactId>asakusa-dag-api</artifactId>
+      <version>${asakusafw-dag.version}</version>
+    </dependency>
+    <dependency>
+      <groupId>org.apache.hadoop</groupId>
+      <artifactId>hadoop-common</artifactId>
+    </dependency>
+    <dependency>
+      <groupId>org.slf4j</groupId>
+      <artifactId>slf4j-api</artifactId>
+    </dependency>
+    <dependency>
+      <groupId>org.slf4j</groupId>
+      <artifactId>slf4j-simple</artifactId>
+    </dependency>
+    <dependency>
+      <groupId>junit</groupId>
+      <artifactId>junit</artifactId>
+      <scope>test</scope>
+    </dependency>
+    <dependency>
+      <groupId>org.hamcrest</groupId>
+      <artifactId>hamcrest-library</artifactId>
+      <scope>test</scope>
+    </dependency>
+  </dependencies>
+</project>

--- a/bridge/workaround/hadoop/src/main/java/com/asakusafw/m3bp/workaround/hadoop/WakeUpUserGroupInformation.java
+++ b/bridge/workaround/hadoop/src/main/java/com/asakusafw/m3bp/workaround/hadoop/WakeUpUserGroupInformation.java
@@ -1,0 +1,43 @@
+/**
+ * Copyright 2011-2016 Asakusa Framework Team.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package com.asakusafw.m3bp.workaround.hadoop;
+
+import java.io.IOException;
+
+import org.apache.hadoop.security.UserGroupInformation;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+
+import com.asakusafw.dag.api.processor.ProcessorContext;
+import com.asakusafw.dag.api.processor.ProcessorContext.Editor;
+import com.asakusafw.dag.api.processor.extension.ProcessorContextExtension;
+import com.asakusafw.dag.utils.common.InterruptibleIo;
+
+/**
+ * Forcibly wake-up {@link WakeUpUserGroupInformation}.
+ * @since 0.1.1
+ */
+public class WakeUpUserGroupInformation implements ProcessorContextExtension {
+
+    static final Logger LOG = LoggerFactory.getLogger(WakeUpUserGroupInformation.class);
+
+    @Override
+    public InterruptibleIo install(ProcessorContext context, Editor editor) throws IOException, InterruptedException {
+        LOG.info("workaround: eager wake up UserGroupInformation");
+        UserGroupInformation.isSecurityEnabled();
+        return null;
+    }
+}

--- a/bridge/workaround/hadoop/src/main/java/com/asakusafw/m3bp/workaround/hadoop/package-info.java
+++ b/bridge/workaround/hadoop/src/main/java/com/asakusafw/m3bp/workaround/hadoop/package-info.java
@@ -1,0 +1,19 @@
+/**
+ * Copyright 2011-2016 Asakusa Framework Team.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+/**
+ * Workaround classes for Hadoop environment.
+ */
+package com.asakusafw.m3bp.workaround.hadoop;

--- a/bridge/workaround/hadoop/src/main/resources/META-INF/services/com.asakusafw.dag.api.processor.extension.ProcessorContextExtension
+++ b/bridge/workaround/hadoop/src/main/resources/META-INF/services/com.asakusafw.dag.api.processor.extension.ProcessorContextExtension
@@ -1,0 +1,1 @@
+com.asakusafw.m3bp.workaround.hadoop.WakeUpUserGroupInformation


### PR DESCRIPTION
Using this feature, please manually put the artifact 'com.asakusafw.m3bp.bridge:asakusa-m3bp-workaround-hadoop' into '$ASAKUSA_HOME/{m3bp|ext}/lib'.