### PR TITLE
CMake should always generate Unix Makefiles.

### DIFF
--- a/bridge/client/pom.xml
+++ b/bridge/client/pom.xml
@@ -33,6 +33,8 @@
                   <target xmlns:if="ant:if" xmlns:unless="ant:unless">
                     <mkdir dir="${project.build.directory}/native/test/build" />
                     <exec executable="cmake" dir="${project.build.directory}/native/test/build" failonerror="true">
+                      <arg value="-G" />
+                      <arg value="Unix Makefiles" />
                       <arg value="-DCMAKE_TOOLCHAIN_FILE=${CMAKE_TOOLCHAIN_FILE}" unless:blank="${CMAKE_TOOLCHAIN_FILE}" />
                       <arg value="${basedir}/src/test/native" />
                     </exec>

--- a/bridge/mock/pom.xml
+++ b/bridge/mock/pom.xml
@@ -33,6 +33,8 @@
                   <target xmlns:if="ant:if" xmlns:unless="ant:unless">
                     <mkdir dir="${project.build.directory}/native/test/build" />
                     <exec executable="cmake" dir="${project.build.directory}/native/test/build" failonerror="true">
+                      <arg value="-G" />
+                      <arg value="Unix Makefiles" />
                       <arg value="-DCMAKE_TOOLCHAIN_FILE=${CMAKE_TOOLCHAIN_FILE}" unless:blank="${CMAKE_TOOLCHAIN_FILE}" />
                       <arg value="${basedir}/src/test/native" />
                     </exec>

--- a/bridge/runtime/pom.xml
+++ b/bridge/runtime/pom.xml
@@ -65,6 +65,8 @@
                   <target xmlns:if="ant:if" xmlns:unless="ant:unless">
                     <mkdir dir="${project.build.directory}/native/core" />
                     <exec executable="cmake" dir="${project.build.directory}/native/core" failonerror="true">
+                      <arg value="-G" />
+                      <arg value="Unix Makefiles" />
                       <arg value="-DCMAKE_BUILD_TYPE=${CMAKE_BUILD_TYPE}" unless:blank="${CMAKE_BUILD_TYPE}" />
                       <arg value="-DCMAKE_TOOLCHAIN_FILE=${CMAKE_TOOLCHAIN_FILE}" unless:blank="${CMAKE_TOOLCHAIN_FILE}" />
                       <arg value="-DCMAKE_SKIP_RPATH=ON" />
@@ -95,6 +97,8 @@
                   <target xmlns:if="ant:if" xmlns:unless="ant:unless">
                     <mkdir dir="${project.build.directory}/native/bridge" />
                     <exec executable="cmake" dir="${project.build.directory}/native/bridge" failonerror="true">
+                      <arg value="-G" />
+                      <arg value="Unix Makefiles" />
                       <arg value="-DJNI_HEADER_DIR:string=${project.build.directory}/native/include" />
                       <arg value="-DCUSTOM_LIBRARIES_DIR:string=${project.build.directory}/native/lib" />
                       <arg value="-DM3BP_INCLUDE_DIR:string=${m3bp.location}/include" />
@@ -171,6 +175,8 @@
                   <target xmlns:if="ant:if" xmlns:unless="ant:unless">
                     <mkdir dir="${project.build.directory}/native/test" />
                     <exec executable="cmake" dir="${project.build.directory}/native/test" failonerror="true">
+                      <arg value="-G" />
+                      <arg value="Unix Makefiles" />
                       <arg value="-DCMAKE_TOOLCHAIN_FILE=${CMAKE_TOOLCHAIN_FILE}" unless:blank="${CMAKE_TOOLCHAIN_FILE}" />
                       <arg value="${basedir}/src/test/native" />
                     </exec>

--- a/compiler/core/src/main/java/com/asakusafw/m3bp/compiler/core/extension/NativeValueComparatorParticipant.java
+++ b/compiler/core/src/main/java/com/asakusafw/m3bp/compiler/core/extension/NativeValueComparatorParticipant.java
@@ -234,6 +234,8 @@ public class NativeValueComparatorParticipant extends AbstractCompilerParticipan
 
         List<String> cmakeArgs = new ArrayList<>();
         cmakeArgs.add(project.getBasePath().getAbsolutePath());
+        cmakeArgs.add("-G");
+        cmakeArgs.add("Unix Makefiles");
         cmakeOptions.forEach((k, v) -> cmakeArgs.add(String.format("-D%s=%s", k, v)));
         CommandRunner.run(cmake, project.toFile(PATH_BUILD_DIR), cmakeArgs.stream().toArray(String[]::new));
 


### PR DESCRIPTION
## Summary

Some artifacts and DSL compiler are using `cmake` command, and they may generate platform dependent build scripts (e.g. nmake).

## Background, Problem or Goal of the patch

Using Windows, `cmake` generates build scripts for `nmake` even if cross compiling settings are enabled.

## Design of the fix, or a new feature

We explicitly put `-G "Unix Makefiles"` for each `cmake` command option.

## Related Issue, Pull Request or Code

N/A.

## Wanted reviewer

@akirakw