### PR TITLE
Unlink asakusa-dag-compiler-trace.

### DIFF
--- a/compiler/test-adapter/pom.xml
+++ b/compiler/test-adapter/pom.xml
@@ -18,11 +18,6 @@
       <version>${asakusafw-lang.version}</version>
     </dependency>
     <dependency>
-      <groupId>com.asakusafw.dag.compiler</groupId>
-      <artifactId>asakusa-dag-compiler-trace</artifactId>
-      <version>${asakusafw-dag.version}</version>
-    </dependency>
-    <dependency>
       <groupId>com.asakusafw</groupId>
       <artifactId>asakusa-test-compiler</artifactId>
     </dependency>


### PR DESCRIPTION
## Summary

This commit removes a reference to `asakusa-dag-compiler-trace` at asakusafw/asakusafw-dag.

## Background, Problem or Goal of the patch

The tracing facility has been moved to `asakusa-compiler-extension-trace` at asakusafw/asakusafw-compiler, and it is already in the transitive dependencies (since `0.3.1`).

## Design of the fix, or a new feature

N/A.

## Related Issue, Pull Request or Code

* asakusafw/asakusafw-compiler#52

## Wanted reviewer

@akirakw 