### PR TITLE
Add Hive schema generator extension to compiler.

### DIFF
--- a/gradle/src/main/groovy/com/asakusafw/m3bp/gradle/plugins/internal/AsakusaM3bpSdkPlugin.groovy
+++ b/gradle/src/main/groovy/com/asakusafw/m3bp/gradle/plugins/internal/AsakusaM3bpSdkPlugin.groovy
@@ -95,6 +95,7 @@ class AsakusaM3bpSdkPlugin implements Plugin<Project> {
                 asakusaM3bpCommon "com.asakusafw.lang.compiler:asakusa-compiler-extension-redirector:${base.langVersion}"
                 asakusaM3bpCommon "com.asakusafw.lang.compiler:asakusa-compiler-extension-yaess:${base.langVersion}"
                 asakusaM3bpCommon "com.asakusafw.lang.compiler:asakusa-compiler-extension-directio:${base.langVersion}"
+                asakusaM3bpCommon "com.asakusafw.lang.compiler:asakusa-compiler-extension-hive:${base.langVersion}"
                 asakusaM3bpCommon "com.asakusafw.lang.compiler:asakusa-compiler-extension-windgate:${base.langVersion}"
                 asakusaM3bpCommon "com.asakusafw:simple-graph:${sdk.asakusafwVersion}"
                 asakusaM3bpCommon "com.asakusafw:java-dom:${sdk.asakusafwVersion}"


### PR DESCRIPTION
## Summary

This commit enables to generate Hive schema information on compiling batch applications.

## Background, Problem or Goal of the patch

see asakusafw/asakusafw-compiler#60.

## Design of the fix, or a new feature

Note that, this feature is always active even if target batch application project does not have hive related dependencies. In such case, the compiler will generate empty files for schema info.

## Related Issue, Pull Request or Code

* asakusafw/asakusafw-compiler#60
* asakusafw/asakusafw-compiler#61

## Wanted reviewer

@akirakw
