### PR TITLE
Must clear JNI exceptions before convert them into C++ exceptions.

### DIFF
--- a/bridge/runtime/src/main/native/jni/jniutil.cpp
+++ b/bridge/runtime/src/main/native/jni/jniutil.cpp
@@ -45,6 +45,7 @@ jmethodID find_method(JNIEnv *env, jclass clazz, const char *name, const char *s
 void check_java_exception(JNIEnv *env) {
     jthrowable object = env->ExceptionOccurred();
     if (object) {
+        env->ExceptionClear();
         throw JavaException(object);
     }
 }


### PR DESCRIPTION
## Summary

JNI exceptions must be cleared by using `JNIEnv::ExceptionClear()`.

## Background, Problem or Goal of the patch

In `0.1.1`, exception handling is bad-mannered, which `env->ExceptionClear()` was not called after `env->ExceptionOccurred()` returns non-null values (see: [JNI Spec](http://docs.oracle.com/javase/8/docs/technotes/guides/jni/spec/functions.html#ExceptionOccurred)). This breaks down applications when the engine propagates exceptions occurred in user code.

## Design of the fix, or a new feature

We just add `env->ExceptionClear()` after checking exceptions.

## Related Issue, Pull Request or Code

N/A.

## Wanted reviewer

N/A.
