### PR TITLE
Introduce `-Dmake.parallel` option to build this project.

### DIFF
--- a/README.md
+++ b/README.md
@@ -31,6 +31,7 @@ git submodule update --init
   * `-Pnative-test`
   * `-DCMAKE_BUILD_TYPE=Debug`
   * `-DCMAKE_TOOLCHAIN_FILE=/path/to/toolchain.cmake`
+  * `-Dmake.parallel=N-of-threads`
 
 ### Gradle plug-ins
 

--- a/bridge/runtime/pom.xml
+++ b/bridge/runtime/pom.xml
@@ -14,6 +14,7 @@
   <properties>
     <CMAKE_BUILD_TYPE>Release</CMAKE_BUILD_TYPE>
     <CMAKE_TOOLCHAIN_FILE />
+    <make.parallel />
     <m3bp.location>${basedir}/../../m3bp</m3bp.location>
     <m3bp.version />
   </properties>
@@ -73,7 +74,9 @@
                       <arg value="${m3bp.location}/src" />
                     </exec>
                     <mkdir dir="${project.build.directory}/native/lib" />
-                    <exec executable="make" dir="${project.build.directory}/native/core" failonerror="true" />
+                    <exec executable="make" dir="${project.build.directory}/native/core" failonerror="true">
+                      <arg value="-j${make.parallel}" unless:blank="${make.parallel}" />
+                    </exec>
                     <copy todir="${project.build.directory}/native/lib" flatten="true">
                       <fileset dir="${project.build.directory}/native/core" followsymlinks="true">
                         <include name="**/libm3bp.so" /> <!-- is symlink but copied as a regular file by Ant -->
@@ -107,7 +110,9 @@
                       <arg value="-DCMAKE_SKIP_RPATH=ON" />
                       <arg value="${basedir}/src/main/native" />
                     </exec>
-                    <exec executable="make" dir="${project.build.directory}/native/bridge" failonerror="true" />
+                    <exec executable="make" dir="${project.build.directory}/native/bridge" failonerror="true">
+                      <arg value="-j${make.parallel}" unless:blank="${make.parallel}" />
+                    </exec>
                     <mkdir dir="${project.build.directory}/native/lib" />
                     <copy todir="${project.build.directory}/native/lib" flatten="true">
                       <fileset dir="${project.build.directory}/native/bridge">


### PR DESCRIPTION
## Summary

This commit introduces `-Dmake.parallel` option to build this project using maven. It enables to build C++ source files in the core engine and JNI bridge in parallel.

## Background, Problem or Goal of the patch

Asakusa on M3BP project includes following two native modules written in C++, the core engine and its JNI bridge module. These non-Java modules will be finally built by `make` command as single threaded.

## Design of the fix, or a new feature

This commit add an option `-j<N>` to `make` command only if the `-Dmake.parallel` option was specified to maven build. This may not work other than GNU Make.

## Related Issue, Pull Request or Code

N/A.

## Wanted reviewer

@akirakw 