### PR TITLE
Support external outputs without any upstream sub-plans.

### DIFF
--- a/compiler/core/src/test/java/com/asakusafw/m3bp/compiler/core/M3bpJobflowProcessorTest.java
+++ b/compiler/core/src/test/java/com/asakusafw/m3bp/compiler/core/M3bpJobflowProcessorTest.java
@@ -252,6 +252,35 @@ public class M3bpJobflowProcessorTest extends M3bpCompilerTesterRoot {
         });
     }
 
+    /**
+     * Orphaned output.
+     * @throws Exception if failed
+     */
+    @Test
+    public void testio_output_orphaned() throws Exception {
+        testio.output("t", MockDataModel.class, o -> {
+            assertThat(o, hasSize(0));
+        });
+        run(profile, executor, g -> g
+                .output("out", TestOutput.of("t", MockDataModel.class)
+                        .withGenerator(true)));
+    }
+
+    /**
+     * Direct I/O flat output.
+     * @throws Exception if failed
+     */
+    @Test
+    public void directio_output_orphaned() throws Exception {
+        enableDirectIo();
+        run(profile, executor, g -> g
+                .output("out", DirectOutput.of("output", "*.bin", MockDataFormat.class)
+                        .withDeletePatterns("*.bin")));
+        directio.output("output", "*.bin", MockDataFormat.class, o -> {
+            assertThat(o, hasSize(0));
+        });
+    }
+
     private void enableDirectIo() {
         Configuration configuration = directio.getContext().newConfiguration();
         profile.forFrameworkInstallation().add(LOCATION_CORE_CONFIGURATION, o -> configuration.writeXml(o));

--- a/compiler/tester/src/main/java/com/asakusafw/m3bp/compiler/tester/externalio/TestInput.java
+++ b/compiler/tester/src/main/java/com/asakusafw/m3bp/compiler/tester/externalio/TestInput.java
@@ -23,6 +23,8 @@ import com.asakusafw.vocabulary.external.ImporterDescription;
 /**
  * An implementation of {@link ImporterDescription} for testing.
  * {@link TestExternalPortProcessor} can process this description.
+ * @since 0.1.0
+ * @version 0.1.2
  */
 public abstract class TestInput implements ImporterDescription {
 
@@ -32,7 +34,7 @@ public abstract class TestInput implements ImporterDescription {
      * @param dataType the data type
      * @return the created instance
      */
-    public static TestInput of(String id, Class<?> dataType) {
+    public static TestInput.Basic of(String id, Class<?> dataType) {
         return new Basic(id, dataType, DataSize.UNKNOWN);
     }
 
@@ -43,7 +45,7 @@ public abstract class TestInput implements ImporterDescription {
      * @param dataSize the data size
      * @return the created instance
      */
-    public static TestInput of(String id, Class<?> dataType, DataSize dataSize) {
+    public static TestInput.Basic of(String id, Class<?> dataType, DataSize dataSize) {
         return new Basic(id, dataType, dataSize);
     }
 
@@ -54,7 +56,7 @@ public abstract class TestInput implements ImporterDescription {
      * @param dataSize the data size
      * @return the created instance
      */
-    public static TestInput of(String id, Class<?> dataType, ExternalInputInfo.DataSize dataSize) {
+    public static TestInput.Basic of(String id, Class<?> dataType, ExternalInputInfo.DataSize dataSize) {
         return new Basic(id, dataType, DataSize.valueOf(dataSize.name()));
     }
 

--- a/compiler/tester/src/main/java/com/asakusafw/m3bp/compiler/tester/externalio/TestOutput.java
+++ b/compiler/tester/src/main/java/com/asakusafw/m3bp/compiler/tester/externalio/TestOutput.java
@@ -15,6 +15,8 @@
  */
 package com.asakusafw.m3bp.compiler.tester.externalio;
 
+import java.util.Collections;
+
 import com.asakusafw.lang.compiler.model.description.Descriptions;
 import com.asakusafw.lang.compiler.model.description.ImmediateDescription;
 import com.asakusafw.lang.compiler.model.info.ExternalOutputInfo;
@@ -23,6 +25,8 @@ import com.asakusafw.vocabulary.external.ExporterDescription;
 /**
  * An implementation of {@link ExporterDescription} for testing.
  * {@link TestExternalPortProcessor} can process this description.
+ * @since 0.1.0
+ * @version 0.1.2
  */
 public abstract class TestOutput implements ExporterDescription {
 
@@ -32,7 +36,7 @@ public abstract class TestOutput implements ExporterDescription {
      * @param dataType the data type
      * @return the created instance
      */
-    public static TestOutput of(String id, Class<?> dataType) {
+    public static TestOutput.Basic of(String id, Class<?> dataType) {
         return new Basic(id, dataType);
     }
 
@@ -43,6 +47,12 @@ public abstract class TestOutput implements ExporterDescription {
     public abstract String getId();
 
     /**
+     * Returns whether or not this output is a generator.
+     * @return {@code true} if it is generator
+     */
+    public abstract boolean isGenerator();
+
+    /**
      * Returns an {@link ExternalOutputInfo} object for this.
      * @return {@link ExternalOutputInfo} object
      */
@@ -51,6 +61,8 @@ public abstract class TestOutput implements ExporterDescription {
                 Descriptions.classOf(getClass()),
                 TestExternalPortProcessor.MODULE_NAME,
                 Descriptions.classOf(getModelType()),
+                isGenerator(),
+                Collections.emptySet(),
                 new ImmediateDescription(Descriptions.typeOf(String.class), getId()));
     }
 
@@ -62,6 +74,8 @@ public abstract class TestOutput implements ExporterDescription {
         private final String id;
 
         private final Class<?> aClass;
+
+        private boolean generator;
 
         /**
          * Creates a new instance.
@@ -81,6 +95,21 @@ public abstract class TestOutput implements ExporterDescription {
         @Override
         public Class<?> getModelType() {
             return aClass;
+        }
+
+        @Override
+        public boolean isGenerator() {
+            return generator;
+        }
+
+        /**
+         * Sets whether or not this output is a generator.
+         * @param newValue {@code true} if it is generator
+         * @return this
+         */
+        public Basic withGenerator(boolean newValue) {
+            this.generator = newValue;
+            return this;
         }
     }
 }


### PR DESCRIPTION
## Summary

This commit enables to compile external outputs without any upstream sources.

## Background, Problem or Goal of the patch

Since asakusafw/asakusafw-compiler#63, external outputs may have generator constraint and it allows the outputs have no upstream sources. 

## Design of the fix, or a new feature

In this commit the compiler always checks whether or not the vertex has upstream sources or not, and replace empty sources outputs into void output operation.

## Related Issue, Pull Request or Code

* asakusafw/asakusafw-compiler#63

## Wanted reviewer

N/A.
