### PR TITLE
Raise exception if unsafe output buffer was exceeded.

### DIFF
--- a/bridge/runtime/src/main/java/com/asakusafw/m3bp/mirror/unsafe/UnsafePageDataOutput.java
+++ b/bridge/runtime/src/main/java/com/asakusafw/m3bp/mirror/unsafe/UnsafePageDataOutput.java
@@ -16,6 +16,7 @@
 package com.asakusafw.m3bp.mirror.unsafe;
 
 import java.io.IOException;
+import java.text.MessageFormat;
 
 import com.asakusafw.dag.utils.buffer.unsafe.UnsafeDataBuffer;
 import com.asakusafw.m3bp.mirror.PageDataOutput;
@@ -36,7 +37,6 @@ public class UnsafePageDataOutput extends UnsafeDataBuffer implements PageDataOu
 
     private long dataThreshold = 0L;
 
-    @SuppressWarnings("unused")
     private long dataEnd = 0L;
 
     private long keyTablePtr = 0L;
@@ -76,8 +76,16 @@ public class UnsafePageDataOutput extends UnsafeDataBuffer implements PageDataOu
         pageTablePtr += Long.BYTES;
 
         writtenPages++;
+        long last = dataBegin;
         dataBegin = dataPtr;
         if (Long.compareUnsigned(writtenPages, maxPages) >= 0 || Long.compareUnsigned(dataPtr, dataThreshold) >= 0) {
+            if (Long.compareUnsigned(dataPtr, dataEnd) > 0) {
+                throw new IllegalStateException(MessageFormat.format(
+                        "unsafe buffer overflow: buffer-size={0}, exceeded={1}, last-page-size: {2}",
+                        dataEnd - basePtr,
+                        dataPtr - dataEnd,
+                        dataPtr - last));
+            }
             flush(false);
         }
     }


### PR DESCRIPTION
## Summary

This commit enable to raise exception when **unsafe** output buffer is exceeded.

## Background, Problem or Goal of the patch

The previous implementation did not check bounds of unsafe buffers, and may crash the application when it is exceeded by segmentation fault. 

## Design of the fix, or a new feature

We add a boundary check just before flushing its buffer, and raises exception if it is exceeded.

## Related Issue, Pull Request or Code

N/A.

## Wanted reviewer

@akirakw 