### PR TITLE
Add workaround of enabling `com.asakusafw.m3bp.output.buffer.size`.

### DIFF
--- a/bridge/runtime/src/main/include/mirror.hpp
+++ b/bridge/runtime/src/main/include/mirror.hpp
@@ -256,6 +256,8 @@ class OutputWriterMirror {
 private:
     m3bp::OutputWriter m_entity;
     OutputPortMirror *m_port;
+    m3bp::size_type m_buffer_size;
+    m3bp::size_type m_record_count;
     bool m_has_key;
     m3bp::OutputBuffer m_buffer;
     bool m_ensured;
@@ -264,12 +266,17 @@ private:
     std::tuple<const void *, m3bp::size_type> m_offsets;
     std::tuple<const void *, m3bp::size_type> m_key_lengths;
     void ensure();
+    void allocate();
 
 public:
     OutputWriterMirror(m3bp::Task *task, m3bp::identifier_type id, OutputPortMirror *port);
     ~OutputWriterMirror();
     bool has_key() {
         return m_has_key;
+    }
+    void configure(m3bp::size_type buffer_size, m3bp::size_type record_count) {
+        m_buffer_size = buffer_size;
+        m_record_count = record_count;
     }
     void flush(size_t record_count);
     m3bp::size_type base_offset();

--- a/bridge/runtime/src/main/java/com/asakusafw/m3bp/mirror/jni/EngineMirrorImpl.java
+++ b/bridge/runtime/src/main/java/com/asakusafw/m3bp/mirror/jni/EngineMirrorImpl.java
@@ -287,10 +287,9 @@ public class EngineMirrorImpl implements EngineMirror, NativeMirror {
             boolean initialize,
             Callback callback) throws IOException, InterruptedException {
         assert runningContext.get() != null;
-        float flushFactor = configuration.getOutputBufferFlushFactor();
         boolean unsafe = useUnsafe;
         ProcessorContext context = runningContext.get();
-        TaskMirrorImpl task = new TaskMirrorImpl(new Pointer(taskReference), flushFactor, unsafe);
+        TaskMirrorImpl task = new TaskMirrorImpl(new Pointer(taskReference), configuration, unsafe);
         VertexProcessorBridge bridge = getBridge(new Pointer(vertexReference), initialize);
         try {
             callback.call(bridge, context, task);

--- a/bridge/runtime/src/main/java/com/asakusafw/m3bp/mirror/jni/TaskMirrorImpl.java
+++ b/bridge/runtime/src/main/java/com/asakusafw/m3bp/mirror/jni/TaskMirrorImpl.java
@@ -18,6 +18,7 @@ package com.asakusafw.m3bp.mirror.jni;
 import java.text.MessageFormat;
 
 import com.asakusafw.dag.utils.common.Arguments;
+import com.asakusafw.m3bp.mirror.ConfigurationMirror;
 import com.asakusafw.m3bp.mirror.Identifier;
 import com.asakusafw.m3bp.mirror.InputReaderMirror;
 import com.asakusafw.m3bp.mirror.OutputWriterMirror;
@@ -26,20 +27,20 @@ import com.asakusafw.m3bp.mirror.TaskMirror;
 /**
  * JNI bridge of {@link TaskMirror}.
  * @since 0.1.0
- * @version 0.1.1
+ * @version 0.1.2
  */
 public class TaskMirrorImpl implements TaskMirror, NativeMirror {
 
     private final Pointer reference;
 
-    private final float flushFactor;
+    private final ConfigurationMirror configuration;
 
     private final boolean unsafe;
 
-    TaskMirrorImpl(Pointer reference, float flushFactor, boolean unsafe) {
+    TaskMirrorImpl(Pointer reference, ConfigurationMirror configuration, boolean unsafe) {
         Arguments.requireNonNull(reference);
         this.reference = reference;
-        this.flushFactor = flushFactor;
+        this.configuration = configuration;
         this.unsafe = unsafe;
     }
 
@@ -71,12 +72,15 @@ public class TaskMirrorImpl implements TaskMirror, NativeMirror {
 
     @Override
     public OutputWriterMirror output(Identifier id) {
+        ConfigurationMirror conf = configuration;
         Arguments.requireNonNull(id);
-        Pointer ref = new Pointer(output0(getPointer().getAddress(), id.getValue()));
+        Pointer ref = new Pointer(output0(
+                getPointer().getAddress(), id.getValue(),
+                conf.getOutputBufferSize(), conf.getOutputRecordsPerBuffer()));
         if (unsafe) {
-            return new OutputWriterMirrorUnsafe(ref, flushFactor);
+            return new OutputWriterMirrorUnsafe(ref, conf.getOutputBufferFlushFactor());
         } else {
-            return new OutputWriterMirrorImpl(ref, flushFactor);
+            return new OutputWriterMirrorImpl(ref, conf.getOutputBufferFlushFactor());
         }
     }
 
@@ -94,7 +98,7 @@ public class TaskMirrorImpl implements TaskMirror, NativeMirror {
 
     private static native long input0(long self, long id);
 
-    private static native long output0(long self, long id);
+    private static native long output0(long self, long id, long bufferSize, long recordCount);
 
     private static native long logicalTaskId0(long self);
 

--- a/bridge/runtime/src/main/native/jni/TaskMirrorImpl.cpp
+++ b/bridge/runtime/src/main/native/jni/TaskMirrorImpl.cpp
@@ -81,14 +81,15 @@ JNIEXPORT jlong JNICALL Java_com_asakusafw_m3bp_mirror_jni_TaskMirrorImpl_input0
 /*
  * Class:     com_asakusafw_m3bp_mirror_jni_TaskMirrorImpl
  * Method:    output0
- * Signature: (JJ)J
+ * Signature: (JJJJ)J
  */
 JNIEXPORT jlong JNICALL Java_com_asakusafw_m3bp_mirror_jni_TaskMirrorImpl_output0
-(JNIEnv *env, jclass clazz, jlong _self, jlong _id) {
+(JNIEnv *env, jclass clazz, jlong _self, jlong _id, jlong bufferSize, jlong recordCount) {
     try {
         TaskMirror *self = (TaskMirror *) _self;
         m3bp::identifier_type id = static_cast<m3bp::identifier_type>(_id);
         OutputWriterMirror *result = self->output(id);
+        result->configure(bufferSize, recordCount);
         return to_pointer(result);
     } catch (JavaException &e) {
         e.rethrow(env);

--- a/bridge/runtime/src/main/native/mirror/OutputWriterMirror.cpp
+++ b/bridge/runtime/src/main/native/mirror/OutputWriterMirror.cpp
@@ -31,6 +31,8 @@ static void put(std::tuple<const void *, m3bp::size_type> &t, const void *begin,
 OutputWriterMirror::OutputWriterMirror(m3bp::Task *task, m3bp::identifier_type id, OutputPortMirror *port) :
         m_entity(task->output(id)),
         m_port(port),
+        m_buffer_size(0),
+        m_record_count(0),
         m_has_key(m_port->entity().has_key()),
         m_ensured(false) {
 }
@@ -39,7 +41,7 @@ OutputWriterMirror::~OutputWriterMirror() = default;
 
 void OutputWriterMirror::ensure() {
     if (!m_ensured) {
-        m_buffer = std::move(m_entity.allocate_buffer());
+        allocate();
 
         auto contents = m_buffer.data_buffer();
         auto contents_size = m_buffer.data_buffer_size();
@@ -63,7 +65,7 @@ void OutputWriterMirror::ensure() {
 
 std::tuple<const void *, m3bp::size_type, const void *, const void *, m3bp::size_type> OutputWriterMirror::output_buffer() {
     if (!m_ensured) {
-        m_buffer = std::move(m_entity.allocate_buffer());
+        allocate();
         m_ensured = true;
     }
     return std::make_tuple(
@@ -71,6 +73,16 @@ std::tuple<const void *, m3bp::size_type, const void *, const void *, m3bp::size
             m_buffer.offset_table(),
             m_has_key ? m_buffer.key_length_table() : nullptr,
             m_buffer.max_record_count());
+}
+
+void OutputWriterMirror::allocate() {
+    if (!m_ensured) {
+        if (m_buffer_size > 0 && m_record_count > 0) {
+            m_buffer = m_entity.allocate_buffer(m_buffer_size, m_record_count);
+        } else {
+            m_buffer = m_entity.allocate_buffer();
+        }
+    }
 }
 
 m3bp::size_type OutputWriterMirror::base_offset() {


### PR DESCRIPTION
## Summary

This PR enables `com.asakusafw.m3bp.output.buffer.size`.

## Background, Problem or Goal of the patch

Previously configuration `com.asakusafw.m3bp.output.buffer.size` does not work.

## Design of the fix, or a new feature

This commit pass the output buffer size into `OutputWriter` directly.

## Related Issue, Pull Request or Code

N/A.

## Wanted reviewer

@akirakw I think this PR is workaround of the default configuration not working