### PR TITLE
Workaround TLS and dynamic loading issues on Mac OS X

### DIFF
--- a/bridge/assembly/src/main/dist/bootstrap/m3bp/bin/execute.sh
+++ b/bridge/assembly/src/main/dist/bootstrap/m3bp/bin/execute.sh
@@ -157,6 +157,7 @@ else
     export LD_LIBRARY_PATH="$(IFS=:; echo "${_LIBRARYPATH[*]}")"
     "${_EXEC[@]}" \
         $ASAKUSA_M3BP_OPTS \
+        -Djava.library.path="$LD_LIBRARY_PATH" \
         -classpath "$(IFS=:; echo "${_CLASSPATH[*]}")" \
         "com.asakusafw.m3bp.client.Launcher" \
         --client "$_OPT_APPLICATION" \

--- a/bridge/runtime/mac_post_compile.sh
+++ b/bridge/runtime/mac_post_compile.sh
@@ -1,0 +1,41 @@
+#!/bin/bash
+
+set -e
+set -x
+
+LIBDIR=$1
+M3BP_LIBFILE_SIMPLE=libm3bp.dylib
+
+# If M3BP dylib does not exist, nothing to do in this script,
+# for example, on Mac OS X but cross compiling for Linux.
+if [ ! -e ${LIBDIR}/${M3BP_LIBFILE_SIMPLE} ]
+then
+   exit 0
+fi
+
+M3BP_LIBPATH=`ls ${LIBDIR}/libm3bp.*.dylib`
+M3BP_LIBNAME=$(basename ${M3BP_LIBPATH})
+echo "M3BP_LIBNAME: ${M3BP_LIBNAME}"
+
+cp ${BOOST_ROOT}/lib/libboost_*.dylib ${LIBDIR}
+
+for f in ${LIBDIR}/libboost*.dylib
+do
+    for component in log thread system date_time log_setup filesystem regex chrono atomic
+    do
+        install_name_tool -change libboost_${component}.dylib \
+                          @rpath/libboost_${component}.dylib ${f}
+    done
+done
+
+M3BPJNI_LIBFILE=libm3bpjni.dylib
+install_name_tool -change ${M3BP_LIBNAME} @rpath/${M3BP_LIBNAME} ${LIBDIR}/${M3BPJNI_LIBFILE}
+
+for component in log thread system date_time log_setup filesystem regex chrono atomic
+do
+    install_name_tool -change libboost_${component}.dylib \
+                      @rpath/libboost_${component}.dylib \
+                      ${LIBDIR}/${M3BP_LIBNAME}
+done
+
+echo "SUCCESS: mac_post_compile"

--- a/bridge/runtime/pom.xml
+++ b/bridge/runtime/pom.xml
@@ -125,9 +125,10 @@
                     <delete>
                       <fileset dir="${project.build.directory}/native/lib">
                         <include name="libm3bp.so" /> <!-- for only link from m3bpjni -->
+                        <include name="libm3bp.dylib" /> <!-- for only link from m3bpjni -->
                       </fileset>
                     </delete>
-                    <exec executable="${basedir}/mac_post_compile.sh" osfamily="mac"
+                    <exec executable="${basedir}/src/main/native/bin/mac_post_compile.sh" osfamily="mac"
                           failonerror="true">
                       <arg value="${project.build.directory}/native/lib" />
                     </exec>

--- a/bridge/runtime/pom.xml
+++ b/bridge/runtime/pom.xml
@@ -82,6 +82,7 @@
                         <include name="**/libm3bp.so" /> <!-- is symlink but copied as a regular file by Ant -->
                         <include name="**/libm3bp.so.*" />
                         <include name="**/libm3bp.dylib" />
+                        <include name="**/libm3bp.*.dylib" />
                         <include name="**/m3bp.dll" />
                       </fileset>
                     </copy>
@@ -126,6 +127,10 @@
                         <include name="libm3bp.so" /> <!-- for only link from m3bpjni -->
                       </fileset>
                     </delete>
+                    <exec executable="${basedir}/mac_post_compile.sh" osfamily="mac"
+                          failonerror="true">
+                      <arg value="${project.build.directory}/native/lib" />
+                    </exec>
                   </target>
                 </configuration>
               </execution>

--- a/bridge/runtime/src/main/include/adapter.hpp
+++ b/bridge/runtime/src/main/include/adapter.hpp
@@ -16,7 +16,6 @@
 #ifndef ADAPTER_HPP
 #define ADAPTER_HPP
 
-#include <jni.h>
 #include <m3bp/m3bp.hpp>
 
 #include "jniutil.hpp"
@@ -26,7 +25,6 @@ class VertexMirror;
 class ProcessorAdapter : public m3bp::ProcessorBase {
 private:
     VertexMirror *m_mirror;
-    jobject m_bridge_object;
 
 public:
     ProcessorAdapter(VertexMirror *mirror);

--- a/bridge/runtime/src/main/include/jniutil.hpp
+++ b/bridge/runtime/src/main/include/jniutil.hpp
@@ -17,6 +17,7 @@
 #define JNIUTIL_HPP
 
 #include <jni.h>
+#include <string>
 #include <tuple>
 #include <exception>
 

--- a/bridge/runtime/src/main/include/mirror.hpp
+++ b/bridge/runtime/src/main/include/mirror.hpp
@@ -32,13 +32,11 @@ class OutputPortMirror;
 
 class ConfigurationMirror {
 private:
-    EngineMirror *m_engine;
     m3bp::Configuration m_entity;
 
 public:
     using ValueComparatorType = std::function<bool(const void *, const void *)>;
-    ConfigurationMirror(EngineMirror *engine) :
-        m_engine(engine) {}
+    ConfigurationMirror(EngineMirror *engine) {};
     ~ConfigurationMirror() = default;
     m3bp::Configuration &entity() {
         return m_entity;
@@ -159,7 +157,6 @@ public:
 
 class InputPortMirror {
 private:
-    EngineMirror *m_engine;
     VertexMirror *m_parent;
     m3bp::identifier_type m_id;
     m3bp::InputPort m_entity;
@@ -182,7 +179,6 @@ public:
 
 class OutputPortMirror {
 private:
-    EngineMirror *m_engine;
     VertexMirror *m_parent;
     m3bp::identifier_type m_id;
     m3bp::OutputPort m_entity;
@@ -206,7 +202,6 @@ public:
 class InputReaderMirror {
 private:
     m3bp::InputReader m_entity;
-    InputPortMirror *m_port;
     bool m_has_key;
     m3bp::InputBuffer m_buffer;
     m3bp::size_type m_next_key_count;

--- a/bridge/runtime/src/main/native/CMakeLists.txt
+++ b/bridge/runtime/src/main/native/CMakeLists.txt
@@ -12,6 +12,11 @@ link_directories(${CUSTOM_LIBRARIES_DIR})
 
 file(GLOB NATIVE "jni/*.cpp" "mirror/*.cpp" "adapter/*.cpp")
 
+if (APPLE)
+    MESSAGE(STATUS "enabling MacOSX workaround: -DM3BP_NO_THREAD_LOCAL")
+    add_definitions(-DM3BP_NO_THREAD_LOCAL)
+endif()
+
 add_library(m3bpjni SHARED ${NATIVE})
 set_target_properties(m3bpjni PROPERTIES COMPILE_FLAGS "-std=c++11 -Wall")
 set_target_properties(m3bpjni PROPERTIES INTERPROCEDURAL_OPTIMIZATION ON)

--- a/bridge/runtime/src/main/native/bin/mac_post_compile.sh
+++ b/bridge/runtime/src/main/native/bin/mac_post_compile.sh
@@ -1,4 +1,19 @@
 #!/bin/bash
+#
+# Copyright 2011-2016 Asakusa Framework Team.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+#
 
 set -e
 

--- a/bridge/runtime/src/main/native/bin/mac_post_compile.sh
+++ b/bridge/runtime/src/main/native/bin/mac_post_compile.sh
@@ -1,21 +1,25 @@
 #!/bin/bash
 
 set -e
-set -x
 
 LIBDIR=$1
-M3BP_LIBFILE_SIMPLE=libm3bp.dylib
+M3BPJNI_LIBFILE=libm3bpjni.dylib
 
-# If M3BP dylib does not exist, nothing to do in this script,
+# If libm3bpjni.dylib does not exist, nothing to do in this script,
 # for example, on Mac OS X but cross compiling for Linux.
-if [ ! -e ${LIBDIR}/${M3BP_LIBFILE_SIMPLE} ]
+if [ ! -e ${LIBDIR}/${M3BPJNI_LIBFILE} ]
 then
    exit 0
 fi
 
+if [ -z ${BOOST_ROOT} ]
+then
+    echo "$BOOST_ROOT MUST be set to build asakusafw-m3bp on Mac OS X."
+    exit 1
+fi
+
 M3BP_LIBPATH=`ls ${LIBDIR}/libm3bp.*.dylib`
 M3BP_LIBNAME=$(basename ${M3BP_LIBPATH})
-echo "M3BP_LIBNAME: ${M3BP_LIBNAME}"
 
 cp ${BOOST_ROOT}/lib/libboost_*.dylib ${LIBDIR}
 
@@ -28,7 +32,6 @@ do
     done
 done
 
-M3BPJNI_LIBFILE=libm3bpjni.dylib
 install_name_tool -change ${M3BP_LIBNAME} @rpath/${M3BP_LIBNAME} ${LIBDIR}/${M3BPJNI_LIBFILE}
 
 for component in log thread system date_time log_setup filesystem regex chrono atomic

--- a/bridge/runtime/src/main/native/jni/env.cpp
+++ b/bridge/runtime/src/main/native/jni/env.cpp
@@ -19,7 +19,6 @@
 #include <m3bp/m3bp.hpp>
 
 static JavaVM *_java_vm;
-__thread bool _java_attached = false;
 
 JNIEXPORT jint JNI_OnLoad(JavaVM *vm, void *reserved) {
     _java_vm = vm;
@@ -54,7 +53,6 @@ JNIEnv *java_attach() {
     };
     result = _java_vm->AttachCurrentThreadAsDaemon((void**) &env, &thread_args);
     if (result == JNI_OK) {
-        _java_attached = true;
         return env;
     } else {
         throw BridgeError("failed to attach to JVM");
@@ -62,10 +60,5 @@ JNIEnv *java_attach() {
 }
 
 void java_detach() {
-    if (!_java_attached) {
-        return;
-    } else {
-        _java_vm->DetachCurrentThread();
-        _java_attached = false;
-    }
+    _java_vm->DetachCurrentThread();
 }

--- a/bridge/runtime/src/main/native/mirror/InputReaderMirror.cpp
+++ b/bridge/runtime/src/main/native/mirror/InputReaderMirror.cpp
@@ -42,7 +42,6 @@ static m3bp::size_type fit(
 
 InputReaderMirror::InputReaderMirror(m3bp::Task *task, m3bp::identifier_type id, InputPortMirror *port) :
         m_entity(task->input(id)),
-        m_port(port),
         m_has_key(port->entity().movement() == m3bp::Movement::SCATTER_GATHER),
         m_buffer(m_entity.raw_buffer()) {
     put(m_key_offsets, m_buffer.key_offset_table(), 0);

--- a/bridge/runtime/src/main/native/mirror/OutputWriterMirror.cpp
+++ b/bridge/runtime/src/main/native/mirror/OutputWriterMirror.cpp
@@ -18,8 +18,6 @@
 #include <stdexcept>
 #include <cstdint>
 
-static const m3bp::size_type MAX_BUFFER_SIZE = INT32_MAX;
-
 // NOTE: offset buffer requires "(#-of-entries + 1) * sizeof(m3bp::size_type)" bytes
 static const m3bp::size_type MAX_ENTRIES = INT32_MAX / sizeof(m3bp::size_type);
 

--- a/bridge/runtime/src/main/native/mirror/PortMirror.cpp
+++ b/bridge/runtime/src/main/native/mirror/PortMirror.cpp
@@ -18,7 +18,6 @@
 InputPortMirror::InputPortMirror(
         EngineMirror *engine,  VertexMirror *parent,
         m3bp::identifier_type id, const std::string &name) :
-        m_engine(engine),
         m_parent(parent),
         m_id(id),
         m_entity(m3bp::InputPort(name)) {
@@ -29,7 +28,6 @@ InputPortMirror::~InputPortMirror() = default;
 OutputPortMirror::OutputPortMirror(
         EngineMirror *engine, VertexMirror *parent,
         m3bp::identifier_type id, const std::string &name) :
-        m_engine(engine),
         m_parent(parent),
         m_id(id),
         m_entity(m3bp::OutputPort(name)) {


### PR DESCRIPTION
## Summary

This PR makes  asakusa on m3bp work on Mac OS X by avoiding TLS and addressing library loading issues.

## Background, Problem or Goal of the patch

Asakusa on M3BP does not work before this PR because:

1. TLS is not supported by clang on Mac OS X and
2. `LD_LIBRARY_PATH` does not work for loading dynamic library on Mac OS X.

With this PR, Asakusa on M3BP application can be built and run on Mac OS X with the default clang,
and no regression for the following ways of build/run
- build and run on Linux w/ GCC
- build on Mac OS X (w/ GCC, cross  compiling to Linux) and run on Linux

## Design of the fix, or a new feature

For no TLS support, thread local variables are removed or modified (h/t @ashigeru ). For M3BP itself, the PR [1] fixed the TLS issue and it has been already merged.
For dynamic loading issue, `@rpath` is inserted to some dynamic libraries by shell script,
which is called in gradle build process.

## Related Issue, Pull Request or Code

[1] https://github.com/fixstars/m3bp/pull/7

## Wanted reviewer

@akirakw 