### PR TITLE
Enable `-Pnative-test` on MacOSX.

### DIFF
--- a/bridge/runtime/pom.xml
+++ b/bridge/runtime/pom.xml
@@ -166,6 +166,8 @@
             <groupId>org.apache.maven.plugins</groupId>
             <artifactId>maven-surefire-plugin</artifactId>
             <configuration>
+              <!-- On macos, use -Djava.library.path instead of LD_LIBRARY_PATH, and it cannot be set in systemPropertyVariables -->
+              <argLine>-Djava.library.path=${project.build.directory}/native/lib${path.separator}</argLine>
               <environmentVariables>
                 <LD_LIBRARY_PATH>${project.build.directory}/native/lib${path.separator}${env.LD_LIBRARY_PATH}</LD_LIBRARY_PATH>
               </environmentVariables>

--- a/bridge/runtime/src/main/native/bin/mac_post_compile.sh
+++ b/bridge/runtime/src/main/native/bin/mac_post_compile.sh
@@ -47,7 +47,15 @@ do
     done
 done
 
-install_name_tool -change ${M3BP_LIBNAME} @rpath/${M3BP_LIBNAME} ${LIBDIR}/${M3BPJNI_LIBFILE}
+install_name_tool -id "@rpath/${M3BPJNI_LIBFILE}" \
+                  -change ${M3BP_LIBNAME} \
+                          @rpath/${M3BP_LIBNAME} \
+                  -add_rpath "@loader_path/." \
+                  ${LIBDIR}/${M3BPJNI_LIBFILE}
+
+install_name_tool -id "@rpath/${M3BP_LIBNAME}" \
+                  -add_rpath "@loader_path/." \
+                  ${LIBDIR}/${M3BP_LIBNAME}
 
 for component in log thread system date_time log_setup filesystem regex chrono atomic
 do


### PR DESCRIPTION
## Summary

This PR enables `mvn test -Pnative -Pnative-test` on MacOSX.

## Background, Problem or Goal of the patch

#59 enables `mvn compile -Pnative` but tests w/ the built native libraries is still not enabled.

## Design of the fix, or a new feature

We added `-Djava.library.path=${LD_LIBRARY_PATH}` on executing surefire, and fix RPATHs for running tests on Maven.

## Related Issue, Pull Request or Code

* #59 

## Wanted reviewer

@akirakw 
@shino 