### PR TITLE
Lazy output buffer allocation.

### DIFF
--- a/bridge/runtime/src/main/java/com/asakusafw/m3bp/bridge/KeyValueWriterBridge.java
+++ b/bridge/runtime/src/main/java/com/asakusafw/m3bp/bridge/KeyValueWriterBridge.java
@@ -30,8 +30,6 @@ public class KeyValueWriterBridge implements ObjectWriter {
 
     private final OutputWriterMirror writer;
 
-    private final PageDataOutput output;
-
     private final KeyValueSerializer serializer;
 
     /**
@@ -43,13 +41,12 @@ public class KeyValueWriterBridge implements ObjectWriter {
         Arguments.requireNonNull(writer);
         Arguments.requireNonNull(serializer);
         this.writer = writer;
-        this.output = writer.getOutput();
         this.serializer = serializer;
     }
 
     @Override
     public void putObject(Object object) throws IOException, InterruptedException {
-        PageDataOutput o = output;
+        PageDataOutput o = writer.getOutput();
         serializer.serializeKey(object, o);
         o.endKey();
         serializer.serializeValue(object, o);

--- a/bridge/runtime/src/main/java/com/asakusafw/m3bp/bridge/ValueWriterBridge.java
+++ b/bridge/runtime/src/main/java/com/asakusafw/m3bp/bridge/ValueWriterBridge.java
@@ -30,8 +30,6 @@ public class ValueWriterBridge implements ObjectWriter {
 
     private final OutputWriterMirror writer;
 
-    private final PageDataOutput output;
-
     private final Serializer serializer;
 
     /**
@@ -43,13 +41,12 @@ public class ValueWriterBridge implements ObjectWriter {
         Arguments.requireNonNull(writer);
         Arguments.requireNonNull(serializer);
         this.writer = writer;
-        this.output = writer.getOutput();
         this.serializer = serializer;
     }
 
     @Override
     public void putObject(Object object) throws IOException, InterruptedException {
-        PageDataOutput o = output;
+        PageDataOutput o = writer.getOutput();
         serializer.serialize(object, o);
         o.endPage();
     }


### PR DESCRIPTION
## Summary

Output buffers should be initialized lazily.

## Background, Problem or Goal of the patch

Vertices may have so many output ports, and the latest implementation always acquires their output buffer even if they does not have any actual output data. This PR enables to defer acquiring such buffers and then allocate them only if output data exist for each port.

## Design of the fix, or a new feature

In the latest implementation, `OutputWriterMirror{Impl,Unsafe}.ensure()` allocates the internal output buffer, and they are invoked when the instances are created. This PR enables to defer it until going to write a first record of the output.

## Related Issue, Pull Request or Code

N/A.

## Wanted reviewer

@shino
