### PR TITLE
Fix referring a wrong constant field.

### DIFF
--- a/compiler/core/src/main/java/com/asakusafw/m3bp/compiler/core/M3bpDagGenerator.java
+++ b/compiler/core/src/main/java/com/asakusafw/m3bp/compiler/core/M3bpDagGenerator.java
@@ -79,6 +79,7 @@ import com.asakusafw.dag.compiler.model.plan.VertexSpec;
 import com.asakusafw.dag.compiler.model.plan.VertexSpec.OperationOption;
 import com.asakusafw.dag.compiler.model.plan.VertexSpec.OperationType;
 import com.asakusafw.dag.runtime.adapter.DataTable;
+import com.asakusafw.dag.runtime.directio.DirectFileOutputPrepare;
 import com.asakusafw.dag.runtime.internalio.InternalOutputPrepare;
 import com.asakusafw.dag.utils.common.Invariants;
 import com.asakusafw.lang.compiler.api.CompilerOptions;
@@ -729,7 +730,7 @@ public final class M3bpDagGenerator {
         });
         SubPlan.Input entry = externalIo.getOutputSource(vertex.getOrigin());
         ResolvedInputInfo input = new ResolvedInputInfo(
-                InternalOutputPrepare.INPUT_NAME,
+                DirectFileOutputPrepare.INPUT_NAME,
                 edge);
         ResolvedVertexInfo info = new ResolvedVertexInfo(
                 vertex.getId(),


### PR DESCRIPTION
## Summary

This PR fixes referring a wrong constant field.

## Background, Problem or Goal of the patch

`DirectFileOutputPrepare` provides `INPUT_NAME` constant field as its input port name. The compiler should refer it instead of `InternalOutputPrepare.INPUT_NAME` (both are equivalent).

## Design of the fix, or a new feature

N/A.

## Related Issue, Pull Request or Code

N/A.

## Wanted reviewer

N/A.
