### PR TITLE
Fix `operator.checkpoint.remove` default on doc

### DIFF
--- a/docs/ja/source/reference.rst
+++ b/docs/ja/source/reference.rst
@@ -281,7 +281,7 @@ Framework Organizer Plugin ( ``asakusafwOrganizer`` ) への拡張
 
     ``true`` ならば除去し、 ``false`` ならば除去しない。
 
-    既定値: ``true``
+    既定値: ``false``
 
 ``operator.logging.level``
     DSLで指定した ``@Logging`` 演算子のうち、どのレベル以上を表示するか。


### PR DESCRIPTION
## Summary
This PR fixes wrong default value for `operator.checkpoint.remove` in documentation.

(See: https://github.com/asakusafw/asakusafw-compiler/blob/0.3.1/compiler-project/analyzer/src/main/java/com/asakusafw/lang/compiler/analyzer/builtin/CheckpointOperatorRemover.java#L46)

## Background, Problem or Goal of the patch
N/A.

## Design of the fix, or a new feature
N/A.

## Related Issue, Pull Request or Code
N/A.

## Wanted reviewer
N/A.
