### PR TITLE
Avoid using deprecated asakusafwVersion properties in Gradle plug-ins

### DIFF
--- a/gradle/src/main/groovy/com/asakusafw/m3bp/gradle/plugins/internal/AsakusaM3bpOrganizerPlugin.groovy
+++ b/gradle/src/main/groovy/com/asakusafw/m3bp/gradle/plugins/internal/AsakusaM3bpOrganizerPlugin.groovy
@@ -23,6 +23,7 @@ import org.gradle.api.Task
 import com.asakusafw.gradle.plugins.AsakusafwOrganizerPlugin
 import com.asakusafw.gradle.plugins.AsakusafwOrganizerPluginConvention
 import com.asakusafw.gradle.plugins.AsakusafwOrganizerProfile
+import com.asakusafw.gradle.plugins.internal.PluginUtils
 import com.asakusafw.m3bp.gradle.plugins.AsakusafwOrganizerM3bpExtension
 
 /**
@@ -56,6 +57,7 @@ class AsakusaM3bpOrganizerPlugin implements Plugin<Project> {
     }
 
     private void configureConvention() {
+        AsakusaM3bpBaseExtension base = AsakusaM3bpBasePlugin.get(project)
         AsakusafwOrganizerPluginConvention convention = project.asakusafwOrganizer
         convention.extensions.create('m3bp', AsakusafwOrganizerM3bpExtension)
         convention.m3bp.conventionMapping.with {
@@ -64,6 +66,7 @@ class AsakusaM3bpOrganizerPlugin implements Plugin<Project> {
             useSystemNativeDependencies = { false }
             useSystemHadoop = { false }
         }
+        PluginUtils.injectVersionProperty(convention.m3bp, { base.featureVersion })
     }
 
     private void configureProfiles() {
@@ -74,6 +77,7 @@ class AsakusaM3bpOrganizerPlugin implements Plugin<Project> {
     }
 
     private void configureProfile(AsakusafwOrganizerProfile profile) {
+        AsakusaM3bpBaseExtension base = AsakusaM3bpBasePlugin.get(project)
         AsakusafwOrganizerM3bpExtension extension = profile.extensions.create('m3bp', AsakusafwOrganizerM3bpExtension)
         AsakusafwOrganizerM3bpExtension parent = project.asakusafwOrganizer.m3bp
         extension.conventionMapping.with {
@@ -82,6 +86,8 @@ class AsakusaM3bpOrganizerPlugin implements Plugin<Project> {
             useSystemNativeDependencies = { parent.useSystemNativeDependencies }
             useSystemHadoop = { parent.useSystemHadoop }
         }
+        PluginUtils.injectVersionProperty(extension, { base.featureVersion })
+
         AsakusaM3bpOrganizer organizer = new AsakusaM3bpOrganizer(project, profile, extension)
         organizer.configureProfile()
         organizers << organizer

--- a/gradle/src/main/groovy/com/asakusafw/m3bp/gradle/plugins/internal/AsakusaM3bpSdkBasePlugin.groovy
+++ b/gradle/src/main/groovy/com/asakusafw/m3bp/gradle/plugins/internal/AsakusaM3bpSdkBasePlugin.groovy
@@ -87,28 +87,27 @@ class AsakusaM3bpSdkBasePlugin implements Plugin<Project> {
         }
         PluginUtils.afterEvaluate(project) {
             AsakusaM3bpBaseExtension base = AsakusaM3bpBasePlugin.get(project)
-            AsakusafwPluginConvention sdk = AsakusaSdkPlugin.get(project)
-            AsakusafwSdkExtension features = sdk.sdk
+            AsakusafwSdkExtension features = AsakusaSdkPlugin.get(project).sdk
             project.dependencies {
                 if (features.core) {
                     asakusaM3bpCommon "com.asakusafw.m3bp.compiler:asakusa-m3bp-compiler-core:${base.featureVersion}"
                     asakusaM3bpCommon "com.asakusafw.lang.compiler:asakusa-compiler-cli:${base.langVersion}"
                     asakusaM3bpCommon "com.asakusafw.lang.compiler:asakusa-compiler-extension-redirector:${base.langVersion}"
                     asakusaM3bpCommon "com.asakusafw.lang.compiler:asakusa-compiler-extension-yaess:${base.langVersion}"
-                    asakusaM3bpCommon "com.asakusafw:simple-graph:${sdk.asakusafwVersion}"
-                    asakusaM3bpCommon "com.asakusafw:java-dom:${sdk.asakusafwVersion}"
+                    asakusaM3bpCommon "com.asakusafw:simple-graph:${base.coreVersion}"
+                    asakusaM3bpCommon "com.asakusafw:java-dom:${base.coreVersion}"
 
-                    asakusaM3bpCompiler "com.asakusafw:asakusa-dsl-vocabulary:${sdk.asakusafwVersion}"
-                    asakusaM3bpCompiler "com.asakusafw:asakusa-runtime:${sdk.asakusafwVersion}"
-                    asakusaM3bpCompiler "com.asakusafw:asakusa-yaess-core:${sdk.asakusafwVersion}"
+                    asakusaM3bpCompiler "com.asakusafw:asakusa-dsl-vocabulary:${base.coreVersion}"
+                    asakusaM3bpCompiler "com.asakusafw:asakusa-runtime:${base.coreVersion}"
+                    asakusaM3bpCompiler "com.asakusafw:asakusa-yaess-core:${base.coreVersion}"
 
                     if (features.directio) {
                         asakusaM3bpCommon "com.asakusafw.dag.compiler:asakusa-dag-compiler-extension-directio:${base.langVersion}"
-                        asakusaM3bpCompiler "com.asakusafw:asakusa-directio-vocabulary:${sdk.asakusafwVersion}"
+                        asakusaM3bpCompiler "com.asakusafw:asakusa-directio-vocabulary:${base.coreVersion}"
                     }
                     if (features.windgate) {
                         asakusaM3bpCommon "com.asakusafw.dag.compiler:asakusa-dag-compiler-extension-windgate:${base.langVersion}"
-                        asakusaM3bpCompiler "com.asakusafw:asakusa-windgate-vocabulary:${sdk.asakusafwVersion}"
+                        asakusaM3bpCompiler "com.asakusafw:asakusa-windgate-vocabulary:${base.coreVersion}"
                     }
                     if (features.hive) {
                         asakusaM3bpCommon "com.asakusafw.lang.compiler:asakusa-compiler-extension-hive:${base.langVersion}"

--- a/gradle/src/test/groovy/com/asakusafw/m3bp/gradle/plugins/internal/AsakusaM3bpOrganizerPluginTest.groovy
+++ b/gradle/src/test/groovy/com/asakusafw/m3bp/gradle/plugins/internal/AsakusaM3bpOrganizerPluginTest.groovy
@@ -78,6 +78,18 @@ class AsakusaM3bpOrganizerPluginTest {
     }
 
     /**
+     * Test for {@code project.asakusafwOrganizer.m3bp.version}.
+     */
+    @Test
+    void extension_version() {
+        project.asakusaM3bpBase.featureVersion = '__VERSION__'
+        assert project.asakusafwOrganizer.m3bp.version == '__VERSION__'
+        assert project.asakusafwOrganizer.profiles.dev.m3bp.version == '__VERSION__'
+        assert project.asakusafwOrganizer.profiles.prod.m3bp.version == '__VERSION__'
+        assert project.asakusafwOrganizer.profiles.other.m3bp.version == '__VERSION__'
+    }
+
+    /**
      * test for extension.
      */
     @Test


### PR DESCRIPTION
## Summary

This PR fixes for upstream changes in asakusafw/asakusafw-sdk#111, which has made `*.asakusafwVersion` properties deprecated.

## Background, Problem or Goal of the patch

see asakusafw/asakusafw-sdk#111.

## Design of the fix, or a new feature

The following convention properties are also now available:

* `asakusafwOrganizer.m3bp.version`
  * Asakusa on M3BP libraries version.
* `asakusafwOrganizer.profiles.<profile-name>.m3bp.version`
  * Asakusa on M3BP libraries version.

## Related Issue, Pull Request or Code

* asakusafw/asakusafw-sdk#111

## Wanted reviewer

@akirakw 