### PR TITLE
Support `*Tester.configure()` in M3BP tasks.

### DIFF
--- a/compiler/test-adapter/pom.xml
+++ b/compiler/test-adapter/pom.xml
@@ -13,6 +13,11 @@
 
   <dependencies>
     <dependency>
+      <groupId>${project.groupId}</groupId>
+      <artifactId>asakusa-m3bp-compiler-common</artifactId>
+      <version>${project.version}</version>
+    </dependency>
+    <dependency>
       <groupId>com.asakusafw.lang.compiler</groupId>
       <artifactId>asakusa-compiler-test-adapter</artifactId>
       <version>${asakusafw-lang.version}</version>

--- a/compiler/test-adapter/src/main/java/com/asakusafw/m3bp/compiler/testdriver/adapter/M3bpCompilerProfileInitializer.java
+++ b/compiler/test-adapter/src/main/java/com/asakusafw/m3bp/compiler/testdriver/adapter/M3bpCompilerProfileInitializer.java
@@ -15,17 +15,23 @@
  */
 package com.asakusafw.m3bp.compiler.testdriver.adapter;
 
+import java.util.Arrays;
+import java.util.Collection;
 import java.util.Collections;
 import java.util.LinkedHashMap;
 import java.util.Map;
 
+import com.asakusafw.lang.compiler.common.Location;
 import com.asakusafw.lang.compiler.extension.redirector.RedirectorParticipant;
 import com.asakusafw.lang.compiler.testdriver.adapter.CompilerProfileInitializer;
 import com.asakusafw.lang.compiler.tester.CompilerProfile;
+import com.asakusafw.m3bp.compiler.common.M3bpTask;
 import com.asakusafw.testdriver.compiler.CompilerConfiguration;
 
 /**
  * {@link CompilerProfileInitializer} for M3BP.
+ * @since 0.1.0
+ * @version 0.2.0
  */
 public class M3bpCompilerProfileInitializer implements CompilerProfileInitializer {
 
@@ -49,11 +55,16 @@ public class M3bpCompilerProfileInitializer implements CompilerProfileInitialize
     }
 
     @Override
+    public Collection<Location> getLauncherPaths() {
+        return Arrays.asList(M3bpTask.PATH_COMMAND);
+    }
+
+    @Override
     public void initialize(CompilerProfile profile, CompilerConfiguration configuration) {
         installOptions(REDIRECT_MAP, profile, configuration);
     }
 
-    private void installOptions(
+    private static void installOptions(
             Map<String, String> options,
             CompilerProfile profile,
             CompilerConfiguration configuration) {


### PR DESCRIPTION
## Summary

This PR enables Asakusa on M3BP testkit use `*Tester.configure()`.

## Background, Problem or Goal of the patch

see asakusafw/asakusafw#688.

## Design of the fix, or a new feature

N/A.

## Related Issue, Pull Request or Code

* asakusafw/asakusafw#688
* asakusafw/asakusafw-compiler#86

## Wanted reviewer

@akirakw 