### PR TITLE
Fix duplicate asakusaVersion output

### DIFF
--- a/gradle/src/main/groovy/com/asakusafw/m3bp/gradle/plugins/internal/AsakusaM3bpSdkPlugin.groovy
+++ b/gradle/src/main/groovy/com/asakusafw/m3bp/gradle/plugins/internal/AsakusaM3bpSdkPlugin.groovy
@@ -108,7 +108,6 @@ class AsakusaM3bpSdkPlugin implements Plugin<Project> {
             project.tasks.compileBatchapp.dependsOn task
             project.tasks.jarBatchapp.from { task.outputDirectory }
         }
-        extendVersionsTask()
         PluginUtils.afterEvaluate(project) {
             AsakusaCompileTask task = project.tasks.getByName(TASK_COMPILE)
             Map<String, String> map = [:]
@@ -120,12 +119,6 @@ class AsakusaM3bpSdkPlugin implements Plugin<Project> {
                 File f = project.file(sdk.logbackConf)
                 task.systemProperties.put('logback.configurationFile', f.absolutePath)
             }
-        }
-    }
-
-    private void extendVersionsTask() {
-        project.tasks.getByName(AsakusafwBasePlugin.TASK_VERSIONS) << {
-            logger.lifecycle "M3BP: ${AsakusaM3bpBasePlugin.get(project).featureVersion}"
         }
     }
 }


### PR DESCRIPTION
## Summary
This PR fixes duplicate version outputs when executing `asakusaVersion` task with `asakusa-m3bp` Gradle Plugin.

## Background, Problem or Goal of the patch
This is caused by duplication of asakusaVersion extension in AsakusaM3bpSdkPlugin.groovy and AsakusaM3bpBasePlugin.groovy.

## Design of the fix, or a new feature
This PR removes extendVersionsTask from AsakusaM3bpSdkPlugin.

## Related Issue, Pull Request or Code
N/A.

## Wanted reviewer
@ashigeru 