### PR TITLE
Remove `Task.leftShift()` in Gradle plug-ins.

### DIFF
--- a/gradle/src/main/groovy/com/asakusafw/m3bp/gradle/plugins/internal/AsakusaM3bpBasePlugin.groovy
+++ b/gradle/src/main/groovy/com/asakusafw/m3bp/gradle/plugins/internal/AsakusaM3bpBasePlugin.groovy
@@ -120,7 +120,7 @@ class AsakusaM3bpBasePlugin implements Plugin<Project> {
     }
 
     private void extendVersionsTask() {
-        project.tasks.getByName(AsakusafwBasePlugin.TASK_VERSIONS) << {
+        project.tasks.getByName(AsakusafwBasePlugin.TASK_VERSIONS).doLast {
             logger.lifecycle "Asakusa on M3BP: ${extension.featureVersion}"
         }
     }


### PR DESCRIPTION
## Summary

This PR replaces `Task.leftShift()` with `Task.doLast()` in Gradle plug-ins.

## Background, Problem or Goal of the patch

`Task.leftShift()` will have become deprecated from Gradle `3.2`.

## Design of the fix, or a new feature

N/A.

## Related Issue, Pull Request or Code

N/A.

## Wanted reviewer

@akirakw 