### PR TITLE
Enable framework API outer the batchapp project.

### DIFF
--- a/bridge/client/src/main/java/com/asakusafw/m3bp/client/GraphExecutor.java
+++ b/bridge/client/src/main/java/com/asakusafw/m3bp/client/GraphExecutor.java
@@ -33,6 +33,7 @@ import org.apache.hadoop.conf.Configuration;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 
+import com.asakusafw.bridge.api.activate.ApiActivator;
 import com.asakusafw.bridge.broker.ResourceBroker;
 import com.asakusafw.bridge.broker.ResourceSession;
 import com.asakusafw.bridge.stage.StageInfo;
@@ -168,6 +169,7 @@ public final class GraphExecutor {
                 context.getResource(StageInfo.class).get());
         session.put(ResourceConfiguration.class,
                 new HadoopConfiguration(context.getResource(Configuration.class).get()));
+        ApiActivator.load(context.getClassLoader()).forEach(a -> session.schedule(a.activate()));
     }
 
     private static void configureInt(IntConsumer target, ProcessorContext context, String key) {


### PR DESCRIPTION
## Summary

This PR enables the Asakusa Framework APIs even if the caller is out of batch application projects (e.g. `$ASAKUSA_HOME/ext/lib`).

## Background, Problem or Goal of the patch

In the latest implementation, Framework API is only available in the batch application projects, because "API redirector" only rewrites classes in the jobflow libraries.

## Design of the fix, or a new feature

This PR uses `ApiActivator` facilities, which has been introduced for Asakusa Vanilla. It redirects the original framework API (actually they are only stub classes - see asakusafw/asakusafw#683) into other implementations.

## Related Issue, Pull Request or Code

* asakusafw/asakusafw#683
* asakusafw/asakusafw-compiler#81

## Wanted reviewer

@akirakw 
