### PR TITLE
Restore native-maven-plugin version.

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -44,6 +44,7 @@
     <plugin.assembly.version>2.6</plugin.assembly.version>
     <plugin.jar.version>3.0.2</plugin.jar.version>
     <plugin.shade.version>2.4.3</plugin.shade.version>
+    <plugin.native.version>1.0-alpha-8</plugin.native.version>
     <plugin.javadoc.version>2.10.4</plugin.javadoc.version>
     <plugin.release.version>2.5.2</plugin.release.version>
     <plugin.deploy.version>2.8.2</plugin.deploy.version>
@@ -330,6 +331,11 @@ encoding/<project>=UTF-8
           <groupId>org.apache.maven.plugins</groupId>
           <artifactId>maven-assembly-plugin</artifactId>
           <version>${plugin.assembly.version}</version>
+        </plugin>
+        <plugin>
+          <groupId>org.codehaus.mojo</groupId>
+          <artifactId>native-maven-plugin</artifactId>
+          <version>${plugin.native.version}</version>
         </plugin>
         <plugin>
           <groupId>org.apache.maven.plugins</groupId>


### PR DESCRIPTION
## Summary

This PR restores native-maven-plugin version.

## Background, Problem or Goal of the patch

In asakusafw/asakusafw-m3bp#84, we removed native-maven-plugin declaration from `<pluginManagement>` section but it is still required in `asakusa-m3bp-runtime`.

Maven had raised following warnings:

> [WARNING] Some problems were encountered while building the effective model for com.asakusafw.m3bp.bridge:asakusa-m3bp-runtime:jar:0.2.1-SNAPSHOT
> [WARNING] 'build.plugins.plugin.version' for org.codehaus.mojo:native-maven-plugin is missing. @ com.asakusafw.m3bp.bridge:asakusa-m3bp-runtime:[unknown-version], .../asakusafw-m3bp/bridge/runtime/pom.xml, line 26, column 19

## Design of the fix, or a new feature

N/A.

## Related Issue, Pull Request or Code

N/A.

## Wanted reviewer

@akirakw 