### PR TITLE
Remove TLS workaround for Mac OSX.

### DIFF
--- a/bridge/runtime/src/main/native/CMakeLists.txt
+++ b/bridge/runtime/src/main/native/CMakeLists.txt
@@ -12,11 +12,6 @@ link_directories(${CUSTOM_LIBRARIES_DIR})
 
 file(GLOB NATIVE "jni/*.cpp" "mirror/*.cpp" "adapter/*.cpp")
 
-if (APPLE)
-    MESSAGE(STATUS "enabling MacOSX workaround: -DM3BP_NO_THREAD_LOCAL")
-    add_definitions(-DM3BP_NO_THREAD_LOCAL)
-endif()
-
 add_library(m3bpjni SHARED ${NATIVE})
 set_target_properties(m3bpjni PROPERTIES COMPILE_FLAGS "-std=c++11 -Wall")
 set_target_properties(m3bpjni PROPERTIES INTERPROCEDURAL_OPTIMIZATION ON)

--- a/bridge/runtime/src/main/native/jni/env.cpp
+++ b/bridge/runtime/src/main/native/jni/env.cpp
@@ -19,7 +19,7 @@
 #include <m3bp/m3bp.hpp>
 
 static JavaVM *_java_vm;
-__thread bool _java_attached = false;
+thread_local bool _java_attached = false;
 
 JNIEXPORT jint JNI_OnLoad(JavaVM *vm, void *reserved) {
     _java_vm = vm;

--- a/bridge/runtime/src/main/native/jni/env.cpp
+++ b/bridge/runtime/src/main/native/jni/env.cpp
@@ -19,6 +19,7 @@
 #include <m3bp/m3bp.hpp>
 
 static JavaVM *_java_vm;
+__thread bool _java_attached = false;
 
 JNIEXPORT jint JNI_OnLoad(JavaVM *vm, void *reserved) {
     _java_vm = vm;
@@ -53,6 +54,7 @@ JNIEnv *java_attach() {
     };
     result = _java_vm->AttachCurrentThreadAsDaemon((void**) &env, &thread_args);
     if (result == JNI_OK) {
+        _java_attached = true;
         return env;
     } else {
         throw BridgeError("failed to attach to JVM");
@@ -60,5 +62,10 @@ JNIEnv *java_attach() {
 }
 
 void java_detach() {
-    _java_vm->DetachCurrentThread();
+    if (!_java_attached) {
+        return;
+    } else {
+        _java_vm->DetachCurrentThread();
+        _java_attached = false;
+    }
 }

--- a/bridge/runtime/src/main/native/jni/jniutil.cpp
+++ b/bridge/runtime/src/main/native/jni/jniutil.cpp
@@ -15,7 +15,7 @@
  */
 #include "jniutil.hpp"
 
-static __thread jmethodID _object_to_string = nullptr;
+static thread_local jmethodID _object_to_string = nullptr;
 
 jlong to_pointer(void *p) {
     return (jlong) p;

--- a/bridge/runtime/src/main/native/jni/jniutil.cpp
+++ b/bridge/runtime/src/main/native/jni/jniutil.cpp
@@ -15,9 +15,7 @@
  */
 #include "jniutil.hpp"
 
-#ifndef M3BP_NO_THREAD_LOCAL
-static thread_local jmethodID _object_to_string = nullptr;
-#endif
+static __thread jmethodID _object_to_string = nullptr;
 
 jlong to_pointer(void *p) {
     return (jlong) p;
@@ -76,19 +74,12 @@ std::string java_to_string(JNIEnv *env, jobject object) {
         return std::string("null");
     }
     LocalFrame(env, 4);
-#ifndef M3BP_NO_THREAD_LOCAL
     if (!_object_to_string) {
         jclass clazz = env->FindClass("java/lang/Object");
         check_java_exception(env);
         _object_to_string = env->GetMethodID(clazz, "toString", "()Ljava/lang/String;");
         check_java_exception(env);
     }
-#else
-    jclass clazz = env->FindClass("java/lang/Object");
-    check_java_exception(env);
-    jmethodID _object_to_string = env->GetMethodID(clazz, "toString", "()Ljava/lang/String;");
-    check_java_exception(env);
-#endif
     jstring string = (jstring) env->CallObjectMethod(object, _object_to_string);
     check_java_exception(env);
     if (!string) {


### PR DESCRIPTION
## Summary

This removes TLS workaround for Mac OSX.

## Background, Problem or Goal of the patch

Thread-local Storage has been enabled on Mac OSX from `XCode >= 8.2`.

## Design of the fix, or a new feature

This reverts ff802fc0019e83d6068341e2baf68691cb9a299a and replaces `__thread` keyword with the `thread_local` (as C++11 standard).

## Related Issue, Pull Request or Code

* #59 

## Wanted reviewer

@shino 