### PR TITLE
Fix local exception object leakage in JNI.

### DIFF
--- a/bridge/runtime/src/main/include/env.hpp
+++ b/bridge/runtime/src/main/include/env.hpp
@@ -19,7 +19,6 @@
 #include <jni.h>
 #include <stdexcept>
 
-JavaVM *java_vm();
 JNIEnv *java_env();
 JNIEnv *java_attach();
 void java_detach();

--- a/bridge/runtime/src/main/include/mirror.hpp
+++ b/bridge/runtime/src/main/include/mirror.hpp
@@ -68,6 +68,7 @@ private:
     FlowGraphMirror *m_graph;
     std::string m_library_name;
     void *m_library;
+    std::vector<jobject> m_global_refs;
     jmethodID m_global_initialize_id;
     jmethodID m_global_finalize_id;
     jmethodID m_local_initialize_id;
@@ -93,6 +94,7 @@ public:
         return m_graph;
     }
     void run();
+    void cleanup(JNIEnv *env);
 
     using ValueComparatorType = std::function<bool(const void *, const void *)>;
     ValueComparatorType load_comparator(const std::string &name);

--- a/bridge/runtime/src/main/native/CMakeLists.txt
+++ b/bridge/runtime/src/main/native/CMakeLists.txt
@@ -1,6 +1,6 @@
 cmake_minimum_required(VERSION 2.8)
 
-project(m3bpjni)
+project(m3bpjni CXX)
 
 find_package(JNI)
 

--- a/bridge/runtime/src/main/native/adapter/ProcessorAdapter.cpp
+++ b/bridge/runtime/src/main/native/adapter/ProcessorAdapter.cpp
@@ -26,8 +26,8 @@ ProcessorAdapter::ProcessorAdapter(VertexMirror *vertex) :
 ProcessorAdapter::~ProcessorAdapter() = default;
 
 void ProcessorAdapter::global_initialize(m3bp::Task &task) {
-    JNIEnv *env = java_env();
-    LocalFrame frame(env, 64);
+    LocalFrame frame(64);
+    JNIEnv *env = frame.env();
 
     VertexMirror *vertex = m_mirror;
     EngineMirror *engine = vertex->engine();
@@ -44,8 +44,8 @@ void ProcessorAdapter::global_initialize(m3bp::Task &task) {
 }
 
 void ProcessorAdapter::global_finalize(m3bp::Task &task) {
-    JNIEnv *env = java_env();
-    LocalFrame frame(env, 64);
+    LocalFrame frame(64);
+    JNIEnv *env = frame.env();
 
     VertexMirror *vertex = m_mirror;
     EngineMirror *engine = vertex->engine();
@@ -53,8 +53,8 @@ void ProcessorAdapter::global_finalize(m3bp::Task &task) {
 }
 
 void ProcessorAdapter::thread_local_initialize(m3bp::Task &task) {
-    JNIEnv *env = java_env();
-    LocalFrame frame(env, 64);
+    LocalFrame frame(64);
+    JNIEnv *env = frame.env();
 
     VertexMirror *vertex = m_mirror;
     EngineMirror *engine = vertex->engine();
@@ -62,8 +62,8 @@ void ProcessorAdapter::thread_local_initialize(m3bp::Task &task) {
 }
 
 void ProcessorAdapter::thread_local_finalize(m3bp::Task &task) {
-    JNIEnv *env = java_env();
-    LocalFrame frame(env, 64);
+    LocalFrame frame(64);
+    JNIEnv *env = frame.env();
 
     VertexMirror *vertex = m_mirror;
     EngineMirror *engine = vertex->engine();
@@ -71,8 +71,8 @@ void ProcessorAdapter::thread_local_finalize(m3bp::Task &task) {
 }
 
 void ProcessorAdapter::run(m3bp::Task &task) {
-    JNIEnv *env = java_env();
-    LocalFrame frame(env, 64);
+    LocalFrame frame(64);
+    JNIEnv *env = frame.env();
 
     VertexMirror *vertex = m_mirror;
     EngineMirror *engine = vertex->engine();

--- a/bridge/runtime/src/main/native/jni/EngineMirrorImpl.cpp
+++ b/bridge/runtime/src/main/native/jni/EngineMirrorImpl.cpp
@@ -125,6 +125,7 @@ JNIEXPORT void JNICALL Java_com_asakusafw_m3bp_mirror_jni_EngineMirrorImpl_close
 (JNIEnv *env, jclass clazz, jlong _self) {
     try {
         EngineMirror *self = (EngineMirror *) _self;
+        self->cleanup(env);
         delete_global_ref(env, self->mirror());
         delete self;
     } catch (JavaException &e) {

--- a/bridge/runtime/src/main/native/jni/env.cpp
+++ b/bridge/runtime/src/main/native/jni/env.cpp
@@ -15,6 +15,7 @@
  */
 #include "env.hpp"
 
+#include <sstream>
 #include <iostream>
 #include <m3bp/m3bp.hpp>
 
@@ -26,17 +27,13 @@ JNIEXPORT jint JNI_OnLoad(JavaVM *vm, void *reserved) {
     return JNI_VERSION_1_8;
 }
 
-JavaVM *java_vm() {
-    return _java_vm;
-}
-
 JNIEnv *java_env() {
     JNIEnv *env;
     jint result = _java_vm->GetEnv((void**) &env, JNI_VERSION_1_8);
     if (result == JNI_OK) {
         return env;
     } else {
-        throw BridgeError("failed to obtain JVM");
+        return nullptr;
     }
 }
 
@@ -57,7 +54,9 @@ JNIEnv *java_attach() {
         _java_attached = true;
         return env;
     } else {
-        throw BridgeError("failed to attach to JVM");
+        std::stringstream stream;
+        stream << "failed to obtain JVM: JavaVM->AttachCurrentThreadAsDaemon() returns " << result;
+        throw BridgeError(stream.str());
     }
 }
 

--- a/compiler/core/src/main/java/com/asakusafw/m3bp/compiler/core/extension/NativeValueComparatorParticipant.java
+++ b/compiler/core/src/main/java/com/asakusafw/m3bp/compiler/core/extension/NativeValueComparatorParticipant.java
@@ -160,7 +160,7 @@ public class NativeValueComparatorParticipant extends AbstractCompilerParticipan
 
     private static final String[] FILE_CMAKE_LISTS = {
             "cmake_minimum_required(VERSION 2.8)",
-            "project(all)",
+            "project(all CXX)",
             "set(CMAKE_SKIP_RPATH ON)",
             "file(GLOB NATIVE \"src/*.cpp\")",
             "include_directories(\"include\")",


### PR DESCRIPTION
## Summary

This PR fixes local exception objects leakage in JNI.

## Background, Problem or Goal of the patch

In M3BP, an exception object thrown from vertices is passed to an other thread. It must be a global reference (`JNIEnv::NewGlobalRef`) to prevent from GC.

## Design of the fix, or a new feature

This PR includes two revision:

1. keeps global references of thrown exceptions in vertices instead of local references
2. force attach to Java thread on `global_finalize` - `ProcessLogicalTaskBase::global_cancel` sometimes work outside Java threads

## Related Issue, Pull Request or Code

N/A.

## Wanted reviewer

@akirakw 