### PR TITLE
Enable direct launching script for jobflows.

### DIFF
--- a/bridge/assembly/pom.xml
+++ b/bridge/assembly/pom.xml
@@ -45,6 +45,12 @@
                   <exclude>org.slf4j:*</exclude>
                 </excludes>
               </artifactSet>
+              <relocations>
+                <relocation>
+                  <pattern>com.fasterxml.jackson</pattern>
+                  <shadedPattern>com.asakusafw.m3bp.shaded.com.fasterxml.jackson</shadedPattern>
+                </relocation>
+              </relocations>
               <transformers>
                 <transformer implementation="org.apache.maven.plugins.shade.resource.ServicesResourceTransformer" />
               </transformers>
@@ -96,6 +102,11 @@
     <dependency>
       <groupId>com.asakusafw</groupId>
       <artifactId>simple-graph</artifactId>
+      <scope>runtime</scope> <!-- default: provided -->
+    </dependency>
+    <dependency>
+      <groupId>com.asakusafw</groupId>
+      <artifactId>asakusa-iterative-common</artifactId>
       <scope>runtime</scope> <!-- default: provided -->
     </dependency>
   </dependencies>

--- a/bridge/assembly/src/main/dist/bootstrap/m3bp/bin/execute.sh
+++ b/bridge/assembly/src/main/dist/bootstrap/m3bp/bin/execute.sh
@@ -73,7 +73,14 @@ _OPT_FLOW_ID="$1"
 shift
 _OPT_EXECUTION_ID="$1"
 shift
-_OPT_BATCH_ARGUMENTS="$1"
+if [ "$1" = "-" ]
+then
+    _JAVA_MAIN=com.asakusafw.m3bp.client.M3bpDirect
+    _OPT_BATCH_ARGUMENTS=""
+else
+    _JAVA_MAIN=com.asakusafw.m3bp.client.Launcher
+    _OPT_BATCH_ARGUMENTS="$1"
+fi
 shift
 _OPT_APPLICATION="$1"
 shift
@@ -145,7 +152,7 @@ then
     export HADOOP_CLASSPATH="$HADOOP_CLASSPATH:$(IFS=:; echo "${_CLASSPATH[*]}")"
     export JAVA_LIBRARY_PATH="$(IFS=:; echo "${_LIBRARYPATH[*]}")"
     "${_EXEC[@]}" \
-        "com.asakusafw.m3bp.client.Launcher" \
+        "$_JAVA_MAIN" \
         --client "$_OPT_APPLICATION" \
         --batch-id "$_OPT_BATCH_ID" \
         --flow-id "$_OPT_FLOW_ID" \
@@ -159,7 +166,7 @@ else
         $ASAKUSA_M3BP_OPTS \
         -Djava.library.path="$LD_LIBRARY_PATH" \
         -classpath "$(IFS=:; echo "${_CLASSPATH[*]}")" \
-        "com.asakusafw.m3bp.client.Launcher" \
+        "$_JAVA_MAIN" \
         --client "$_OPT_APPLICATION" \
         --batch-id "$_OPT_BATCH_ID" \
         --flow-id "$_OPT_FLOW_ID" \

--- a/bridge/client/pom.xml
+++ b/bridge/client/pom.xml
@@ -86,12 +86,21 @@
       <version>${asakusafw-lang.version}</version>
     </dependency>
     <dependency>
+      <groupId>com.asakusafw.dag.runtime</groupId>
+      <artifactId>asakusa-dag-iterative</artifactId>
+      <version>${asakusafw-lang.version}</version>
+    </dependency>
+    <dependency>
       <groupId>com.asakusafw.bridge</groupId>
       <artifactId>asakusa-bridge-runtime</artifactId>
     </dependency>
     <dependency>
       <groupId>com.asakusafw</groupId>
       <artifactId>asakusa-runtime</artifactId>
+    </dependency>
+    <dependency>
+      <groupId>com.asakusafw</groupId>
+      <artifactId>asakusa-iterative-common</artifactId>
     </dependency>
     <dependency>
       <groupId>com.asakusafw</groupId>

--- a/bridge/client/src/main/java/com/asakusafw/m3bp/client/Launcher.java
+++ b/bridge/client/src/main/java/com/asakusafw/m3bp/client/Launcher.java
@@ -28,6 +28,7 @@ import org.slf4j.LoggerFactory;
 
 import com.asakusafw.bridge.launch.LaunchConfiguration;
 import com.asakusafw.bridge.launch.LaunchConfigurationException;
+import com.asakusafw.bridge.launch.LaunchInfo;
 import com.asakusafw.bridge.stage.StageInfo;
 import com.asakusafw.dag.api.model.GraphInfo;
 import com.asakusafw.dag.api.processor.basic.BasicProcessorContext;
@@ -62,7 +63,7 @@ public class Launcher {
      */
     public static final int EXEC_INTERRUPTED = 2;
 
-    private final LaunchConfiguration configuration;
+    private final LaunchInfo configuration;
 
     private final ClassLoader applicationLoader;
 
@@ -70,7 +71,7 @@ public class Launcher {
      * Creates a new instance.
      * @param configuration the launching configuration
      */
-    public Launcher(LaunchConfiguration configuration) {
+    public Launcher(LaunchInfo configuration) {
         this(Arguments.requireNonNull(configuration), configuration.getStageClient().getClassLoader());
     }
 
@@ -79,7 +80,7 @@ public class Launcher {
      * @param configuration the launching configuration
      * @param classLoader the application class loader
      */
-    public Launcher(LaunchConfiguration configuration, ClassLoader classLoader) {
+    public Launcher(LaunchInfo configuration, ClassLoader classLoader) {
         Arguments.requireNonNull(configuration);
         Arguments.requireNonNull(classLoader);
         this.configuration = configuration;

--- a/bridge/client/src/main/java/com/asakusafw/m3bp/client/M3bpDirect.java
+++ b/bridge/client/src/main/java/com/asakusafw/m3bp/client/M3bpDirect.java
@@ -1,0 +1,80 @@
+/**
+ * Copyright 2011-2017 Asakusa Framework Team.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package com.asakusafw.m3bp.client;
+
+import java.util.Arrays;
+
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+
+import com.asakusafw.bridge.launch.LaunchConfigurationException;
+import com.asakusafw.dag.iterative.DirectLaunchConfiguration;
+import com.asakusafw.runtime.core.context.RuntimeContext;
+
+/**
+ * Direct program entry of Asakusa on M3BP.
+ * @since 0.2.1
+ * @see Launcher
+ */
+public final class M3bpDirect {
+
+    static final Logger LOG = LoggerFactory.getLogger(M3bpDirect.class);
+
+    private M3bpDirect() {
+        return;
+    }
+
+    /**
+     * Program entry.
+     * @param args launching configurations
+     * @throws LaunchConfigurationException if launching configuration is something wrong
+     */
+    public static void main(String... args) throws LaunchConfigurationException {
+        ClassLoader loader = M3bpDirect.class.getClassLoader();
+        RuntimeContext.set(RuntimeContext.DEFAULT.apply(System.getenv()));
+        RuntimeContext.get().verifyApplication(loader);
+
+        int status = exec(loader, args);
+        if (status != 0) {
+            System.exit(status);
+        }
+    }
+
+    /**
+     * Program entry.
+     * @param loader the launch class loader
+     * @param args launching configurations
+     * @return the exit code
+     * @throws LaunchConfigurationException if launching configuration is something wrong
+     * @see Launcher#EXEC_SUCCESS
+     * @see Launcher#EXEC_ERROR
+     * @see Launcher#EXEC_INTERRUPTED
+     */
+    public static int exec(ClassLoader loader, String... args) throws LaunchConfigurationException {
+        DirectLaunchConfiguration conf = DirectLaunchConfiguration.parse(loader, Arrays.asList(args));
+        int numberOfRounds = conf.getStageInfo().getRoundCount();
+        int currentRound = 0;
+        DirectLaunchConfiguration.Cursor cursor = conf.newCursor();
+        while (cursor.next()) {
+            LOG.info("Round: {}/{}", ++currentRound, numberOfRounds);
+            int result = new Launcher(cursor.get(), loader).exec();
+            if (result != Launcher.EXEC_SUCCESS) {
+                return result;
+            }
+        }
+        return Launcher.EXEC_SUCCESS;
+    }
+}

--- a/bridge/mock/src/main/java/com/asakusafw/m3bp/mirror/jna/MoveEdgeProcessor.java
+++ b/bridge/mock/src/main/java/com/asakusafw/m3bp/mirror/jna/MoveEdgeProcessor.java
@@ -17,6 +17,7 @@ package com.asakusafw.m3bp.mirror.jna;
 
 import java.util.ArrayList;
 import java.util.List;
+import java.util.stream.Collectors;
 
 import com.asakusafw.lang.utils.common.Lang;
 import com.asakusafw.lang.utils.common.Suppliers;
@@ -35,7 +36,9 @@ public class MoveEdgeProcessor implements EdgeProcessor {
 
     @Override
     public List<InputBufferCursor> process() {
-        return Lang.project(candidates, f -> new InputBufferCursor(Suppliers.supplier(f)));
+        return candidates.stream()
+                .map(f -> new InputBufferCursor(Suppliers.supplier(f)))
+                .collect(Collectors.toList());
     }
 
     static List<InputBufferFragment> extract(Iterable<? extends OutputBufferFragment> fragments) {

--- a/compiler/core/src/main/java/com/asakusafw/m3bp/compiler/core/M3bpDirectBatchProcessor.java
+++ b/compiler/core/src/main/java/com/asakusafw/m3bp/compiler/core/M3bpDirectBatchProcessor.java
@@ -1,0 +1,149 @@
+/**
+ * Copyright 2011-2017 Asakusa Framework Team.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package com.asakusafw.m3bp.compiler.core;
+
+import java.io.IOException;
+import java.io.OutputStreamWriter;
+import java.io.PrintWriter;
+import java.io.Writer;
+import java.nio.charset.StandardCharsets;
+import java.text.MessageFormat;
+import java.util.ArrayList;
+import java.util.Arrays;
+import java.util.LinkedHashMap;
+import java.util.List;
+import java.util.Map;
+import java.util.Optional;
+import java.util.Scanner;
+import java.util.regex.Matcher;
+import java.util.regex.Pattern;
+import java.util.stream.Collectors;
+
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+
+import com.asakusafw.lang.compiler.api.BatchProcessor;
+import com.asakusafw.lang.compiler.api.reference.BatchReference;
+import com.asakusafw.lang.compiler.api.reference.CommandTaskReference;
+import com.asakusafw.lang.compiler.api.reference.JobflowReference;
+import com.asakusafw.lang.compiler.api.reference.TaskReference;
+import com.asakusafw.lang.compiler.common.Location;
+import com.asakusafw.lang.utils.common.Arguments;
+import com.asakusafw.lang.utils.common.Optionals;
+import com.asakusafw.m3bp.compiler.common.M3bpTask;
+
+/**
+ * Generates launch scripts of direct Asakusa on M3BP jobflows.
+ * @since 0.2.1
+ */
+public class M3bpDirectBatchProcessor implements BatchProcessor {
+
+    static final Logger LOG = LoggerFactory.getLogger(M3bpDirectBatchProcessor.class);
+
+    private static final int ARG_APPLICATION_INDEX = 4;
+
+    private static final String SCRIPT_TEMPLATE_FILE = "direct.sh.template";
+
+    private static final String[] SCRIPT_TEMPLATE;
+    static {
+        try (Scanner scanner = new Scanner(
+                M3bpDirectBatchProcessor.class.getResourceAsStream(SCRIPT_TEMPLATE_FILE),
+                StandardCharsets.US_ASCII.name())) {
+            List<String> lines = new ArrayList<>();
+            while (scanner.hasNextLine()) {
+                lines.add(scanner.nextLine());
+            }
+            SCRIPT_TEMPLATE = lines.toArray(new String[lines.size()]);
+        }
+    }
+
+    private static final Pattern SCRIPT_PLACEHOLDER = Pattern.compile("\\{{3}(\\w+)\\}{3}"); //$NON-NLS-1$
+
+    /**
+     * Returns the generating script location.
+     * @param flowId the flow ID
+     * @return the script location
+     */
+    public static Location getScriptLocation(String flowId) {
+        Arguments.requireNonNull(flowId);
+        return Location.of(String.format("bin/%s.sh", flowId)); //$NON-NLS-1$
+
+    }
+
+    @Override
+    public void process(Context context, BatchReference source) throws IOException {
+        for (JobflowReference jobflow : source.getJobflows()) {
+            CommandTaskReference command = find(jobflow)
+                    .filter(task -> task.getCommand().equals(M3bpTask.PATH_COMMAND))
+                    .filter(task -> task.getArguments().size() > ARG_APPLICATION_INDEX)
+                    .orElse(null);
+            if (command == null) {
+                LOG.debug("{}:{} does not support m3bp direct launching", source.getBatchId(), jobflow.getFlowId()); //$NON-NLS-1$
+                continue;
+            }
+            Map<String, String> variables = new LinkedHashMap<>();
+            variables.put("BATCH_ID", escape(source.getBatchId()));
+            variables.put("FLOW_ID", escape(jobflow.getFlowId()));
+            variables.put("APPLICATION", escape(command.getArguments().get(ARG_APPLICATION_INDEX).getImage()));
+            Location location = getScriptLocation(jobflow.getFlowId());
+            LOG.debug("generating direct launcher script: {} ({})", location, variables);
+            try (Writer writer = new PrintWriter(
+                    new OutputStreamWriter(context.addResourceFile(location), StandardCharsets.UTF_8))) {
+                write(writer, variables);
+            }
+        }
+    }
+
+    private static Optional<CommandTaskReference> find(JobflowReference jobflow) {
+        List<TaskReference> tasks = Arrays.stream(TaskReference.Phase.values())
+                .flatMap(phase -> jobflow.getTasks(phase).stream())
+                .collect(Collectors.toList());
+        if (tasks.size() != 1) {
+            return Optional.empty();
+        }
+        return Optionals.of(tasks.get(0))
+                .filter(task -> task instanceof CommandTaskReference)
+                .map(CommandTaskReference.class::cast);
+    }
+
+    private static void write(Appendable writer, Map<String, String> variables) throws IOException {
+        for (String line : SCRIPT_TEMPLATE) {
+            Matcher matcher = SCRIPT_PLACEHOLDER.matcher(line);
+            int start = 0;
+            while (matcher.find(start)) {
+                writer.append(line, start, matcher.start());
+                String name = matcher.group(1);
+                String value = variables.get(name);
+                if (value == null) {
+                    throw new IllegalStateException(MessageFormat.format(
+                            "[Internal Error] unknown placeholder: {0}",
+                            name));
+                }
+                writer.append(value);
+                start = matcher.end();
+            }
+            writer.append(line, start, line.length());
+            writer.append('\n'); // LF-only
+        }
+    }
+
+    private static String escape(String value) {
+        if (value.indexOf('\'') >= 0) {
+            throw new IllegalStateException(value);
+        }
+        return String.format("'%s'", value); //$NON-NLS-1$
+    }
+}

--- a/compiler/core/src/main/resources/META-INF/services/com.asakusafw.lang.compiler.api.BatchProcessor
+++ b/compiler/core/src/main/resources/META-INF/services/com.asakusafw.lang.compiler.api.BatchProcessor
@@ -1,0 +1,1 @@
+com.asakusafw.m3bp.compiler.core.M3bpDirectBatchProcessor

--- a/compiler/core/src/main/resources/com/asakusafw/m3bp/compiler/core/direct.sh.template
+++ b/compiler/core/src/main/resources/com/asakusafw/m3bp/compiler/core/direct.sh.template
@@ -1,0 +1,37 @@
+#!/bin/bash
+#
+# Copyright 2011-2017 Asakusa Framework Team.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+#
+
+if [ "$ASAKUSA_HOME" = "" ]
+then
+    echo '$ASAKUSA_HOME is not defined' 1>&2
+    exit 1
+fi
+
+_SCRIPT="$ASAKUSA_HOME/m3bp/bin/execute.sh"
+
+if [ ! -e "$_SCRIPT" ]
+then
+    echo "launcher script is not found: $_SCRIPT"
+fi
+
+_BATCH_ID={{{BATCH_ID}}}
+_FLOW_ID={{{FLOW_ID}}}
+_EXECUTION_ID="$(echo -n $(od -An -t x4 -N4 /dev/random))"
+_BATCH_ARGUMENTS="-"
+_APPLICATION={{{APPLICATION}}}
+
+exec "$_SCRIPT" "$_BATCH_ID" "$_FLOW_ID" "$_EXECUTION_ID" "$_BATCH_ARGUMENTS" "$_APPLICATION" "$@"

--- a/pom.xml
+++ b/pom.xml
@@ -547,6 +547,12 @@ encoding/<project>=UTF-8
       </dependency>
       <dependency>
         <groupId>com.asakusafw</groupId>
+        <artifactId>asakusa-iterative-common</artifactId>
+        <version>${asakusafw.version}</version>
+        <scope>provided</scope>
+      </dependency>
+      <dependency>
+        <groupId>com.asakusafw</groupId>
         <artifactId>simple-graph</artifactId>
         <version>${asakusafw.version}</version>
         <scope>provided</scope>


### PR DESCRIPTION
## Summary

This PR enables DSL compiler for Asakusa on M3BP to generate launcher script for individual jobflows.

## Background, Problem or Goal of the patch

N/A.

## Design of the fix, or a new feature

see asakusafw/asakusafw-compiler#117

## Related Issue, Pull Request or Code

* asakusafw/asakusafw-compiler#117
