### PR TITLE
Enable thread context class loader for workers.

### DIFF
--- a/bridge/runtime/src/main/include/adapter.hpp
+++ b/bridge/runtime/src/main/include/adapter.hpp
@@ -21,6 +21,7 @@
 #include "jniutil.hpp"
 
 class VertexMirror;
+class EngineMirror;
 
 class ProcessorAdapter : public m3bp::ProcessorBase {
 private:
@@ -37,8 +38,13 @@ public:
 };
 
 class ThreadObserverAdapter : public m3bp::ThreadObserverBase {
+private:
+    EngineMirror *m_engine;
+
 public:
-    ThreadObserverAdapter() : m3bp::ThreadObserverBase() {}
+    ThreadObserverAdapter(EngineMirror *engine) :
+            m3bp::ThreadObserverBase(),
+            m_engine(engine) {}
     ~ThreadObserverAdapter() = default;
     virtual void on_initialize() override;
     virtual void on_finalize() override;

--- a/bridge/runtime/src/main/include/mirror.hpp
+++ b/bridge/runtime/src/main/include/mirror.hpp
@@ -69,6 +69,8 @@ private:
     std::string m_library_name;
     void *m_library;
     std::vector<jobject> m_global_refs;
+    jmethodID m_thread_initialize_id;
+    jmethodID m_thread_finalize_id;
     jmethodID m_global_initialize_id;
     jmethodID m_global_finalize_id;
     jmethodID m_local_initialize_id;
@@ -76,12 +78,14 @@ private:
     jmethodID m_run_id;
     jmethodID m_task_count_id;
     jmethodID m_max_concurrency_id;
+    void do_invoke(JNIEnv *env, jmethodID method);
     void do_invoke(JNIEnv *env, VertexMirror *vertex, m3bp::Task &task, jmethodID method);
     jint do_invoke(JNIEnv *env, VertexMirror *vertex, jmethodID method);
 
 public:
     EngineMirror(
         jobject object, const std::string &library_name,
+        jmethodID thread_initialize_id, jmethodID thread_finalize_id,
         jmethodID global_initialize_id, jmethodID global_finalize_id,
         jmethodID local_initialize_id, jmethodID local_finalize_id,
         jmethodID run_id,
@@ -100,6 +104,12 @@ public:
     ValueComparatorType load_comparator(const std::string &name);
     jobject mirror() {
         return m_mirror;
+    }
+    void do_thread_initialize(JNIEnv *env) {
+        do_invoke(env, m_thread_initialize_id);
+    }
+    void do_thread_finalize(JNIEnv *env) {
+        do_invoke(env, m_thread_finalize_id);
     }
     void do_global_initialize(JNIEnv *env, VertexMirror *vertex, m3bp::Task &task) {
         do_invoke(env, vertex, task, m_global_initialize_id);

--- a/bridge/runtime/src/main/native/adapter/ThreadObserverAdapter.cpp
+++ b/bridge/runtime/src/main/native/adapter/ThreadObserverAdapter.cpp
@@ -14,12 +14,18 @@
  * limitations under the License.
  */
 #include "adapter.hpp"
+#include "mirror.hpp"
 #include "env.hpp"
 
 void ThreadObserverAdapter::on_initialize() {
-    java_attach();
+    JNIEnv *env = java_attach();
+    m_engine->do_thread_initialize(env);
 }
 
 void ThreadObserverAdapter::on_finalize() {
+    JNIEnv *env = java_env();
+    if (env) {
+        m_engine->do_thread_finalize(env);
+    }
     java_detach();
 }

--- a/bridge/runtime/src/main/native/jni/EngineMirrorImpl.cpp
+++ b/bridge/runtime/src/main/native/jni/EngineMirrorImpl.cpp
@@ -42,6 +42,8 @@ jlong JNICALL Java_com_asakusafw_m3bp_mirror_jni_EngineMirrorImpl_initialize0
 
         EngineMirror *self = new EngineMirror(
             mirror, library_name,
+            find_method(env, clazz, "doThreadInitialize", "()V"),
+            find_method(env, clazz, "doThreadFinalize", "()V"),
             find_method(env, clazz, "doGlobalInitialize", "(JJ)V"),
             find_method(env, clazz, "doGlobalFinalize", "(JJ)V"),
             find_method(env, clazz, "doLocalInitialize", "(JJ)V"),


### PR DESCRIPTION
## Summary

This PR makes `Thread.getContextClassLoader()` available for worker threads.

## Background, Problem or Goal of the patch

Using old version of Java snappy libraries may raise `NullPointerException` if the context class loader was not set for worker threads.

## Design of the fix, or a new feature

We improves `ThreadObserverAdapter (<: m3bp::ThreadObserverBase)` to invoke Java methods `EngineMirrorImpl.doThread{Initialize,Finalize}()` on initializing/finalizing worker threads, and then configure their context class loader in their methods.

Additionally, this also configures worker threads' name as `m3bp-worker-*`.

## Related Issue, Pull Request or Code

N/A.