### PR TITLE
Disable generating direct launching scripts by default.

### DIFF
--- a/compiler/core/src/main/java/com/asakusafw/m3bp/compiler/core/M3bpDirectBatchProcessor.java
+++ b/compiler/core/src/main/java/com/asakusafw/m3bp/compiler/core/M3bpDirectBatchProcessor.java
@@ -41,10 +41,19 @@ public class M3bpDirectBatchProcessor implements BatchProcessor {
 
     static final Logger LOG = LoggerFactory.getLogger(M3bpDirectBatchProcessor.class);
 
+    static final String KEY_ENABLED = M3bpJobflowProcessor.KEY_PREFIX + "launch.direct"; //$NON-NLS-1$
+
+    static final boolean DEFAULT_ENABLED = false;
+
     private static final int ARG_APPLICATION_INDEX = 4;
 
     @Override
     public void process(Context context, BatchReference source) throws IOException {
+        boolean enabled = context.getOptions().get(KEY_ENABLED, DEFAULT_ENABLED);
+        LOG.debug("m3bp direct launching: {}", enabled); //$NON-NLS-1$
+        if (enabled == false) {
+            return;
+        }
         for (JobflowReference jobflow : source.getJobflows()) {
             CommandTaskReference command = DirectLauncherScriptGenerator.findTask(jobflow)
                     .filter(task -> task.getCommand().equals(M3bpTask.PATH_COMMAND))


### PR DESCRIPTION
## Summary

This PR disables generating direct launching scripts by default.

## Background, Problem or Goal of the patch

see #103.

## Design of the fix, or a new feature

Clients can turn on this feature by the following compiler option:
* `m3bp.launch.direct`
  * whether or not generating direct launching script is enabled
  * default: `false`

## Related Issue, Pull Request or Code

* #103
