### PR TITLE
Gradle plugins should refer `asakusa-lang-gradle`.

### DIFF
--- a/README.md
+++ b/README.md
@@ -37,7 +37,7 @@ git submodule update --init
 
 ```sh
 cd gradle
-./gradlew clean [build] install
+./gradlew clean build [install] [-PmavenLocal]
 ```
 
 ## How to use

--- a/gradle/build.gradle
+++ b/gradle/build.gradle
@@ -53,7 +53,7 @@ repositories {
 
 dependencies {
     compile gradleApi()
-    compile group: 'com.asakusafw', name: 'asakusa-gradle-plugins', version: parentPom.sdkVersion
+    compile group: 'com.asakusafw.lang', name: 'asakusa-lang-gradle', version: parentPom.langVersion
     testCompile gradleTestKit()
     testCompile group: 'com.asakusafw', name: 'asakusa-gradle-plugins', version: parentPom.sdkVersion, classifier: 'tests'
     testCompile 'junit:junit:4.11'
@@ -78,8 +78,8 @@ if (project.hasProperty('referProject')) {
         classpath.entries = classpath.entries.collect { entry ->
             if (entry instanceof org.gradle.plugins.ide.eclipse.model.Library \
                     && entry.moduleVersion \
-                    && entry.moduleVersion.name == 'asakusa-gradle-plugins') {
-                new org.gradle.plugins.ide.eclipse.model.ProjectDependency('/asakusa-gradle-plugins')
+                    && entry.moduleVersion.name in ['asakusa-gradle-plugins', 'asakusa-lang-gradle']) {
+                new org.gradle.plugins.ide.eclipse.model.ProjectDependency("/${entry.moduleVersion.name}")
             } else {
                 entry
             }

--- a/gradle/src/main/groovy/com/asakusafw/m3bp/gradle/plugins/internal/AsakusaM3bpOrganizerPlugin.groovy
+++ b/gradle/src/main/groovy/com/asakusafw/m3bp/gradle/plugins/internal/AsakusaM3bpOrganizerPlugin.groovy
@@ -24,6 +24,7 @@ import com.asakusafw.gradle.plugins.AsakusafwOrganizerPlugin
 import com.asakusafw.gradle.plugins.AsakusafwOrganizerPluginConvention
 import com.asakusafw.gradle.plugins.AsakusafwOrganizerProfile
 import com.asakusafw.gradle.plugins.internal.PluginUtils
+import com.asakusafw.lang.gradle.plugins.internal.AsakusaLangOrganizerPlugin
 import com.asakusafw.m3bp.gradle.plugins.AsakusafwOrganizerM3bpExtension
 
 /**
@@ -40,7 +41,7 @@ class AsakusaM3bpOrganizerPlugin implements Plugin<Project> {
         this.project = project
         this.organizers = project.container(AsakusaM3bpOrganizer)
 
-        project.apply plugin: 'asakusafw-organizer'
+        project.apply plugin: AsakusaLangOrganizerPlugin
         project.apply plugin: AsakusaM3bpBasePlugin
 
         configureConvention()

--- a/gradle/src/main/groovy/com/asakusafw/m3bp/gradle/plugins/internal/AsakusaM3bpSdkBasePlugin.groovy
+++ b/gradle/src/main/groovy/com/asakusafw/m3bp/gradle/plugins/internal/AsakusaM3bpSdkBasePlugin.groovy
@@ -21,6 +21,7 @@ import org.gradle.api.Project
 import com.asakusafw.gradle.plugins.AsakusafwSdkExtension
 import com.asakusafw.gradle.plugins.internal.AsakusaSdkPlugin
 import com.asakusafw.gradle.plugins.internal.PluginUtils
+import com.asakusafw.lang.gradle.plugins.internal.AsakusaLangSdkPlugin
 
 /**
  * A base plug-in of {@link AsakusaM3bpSdkPlugin}.
@@ -35,7 +36,7 @@ class AsakusaM3bpSdkBasePlugin implements Plugin<Project> {
     void apply(Project project) {
         this.project = project
 
-        project.apply plugin: AsakusaSdkPlugin
+        project.apply plugin: AsakusaLangSdkPlugin
         project.apply plugin: AsakusaM3bpBasePlugin
 
         configureTestkit()
@@ -51,15 +52,17 @@ class AsakusaM3bpSdkBasePlugin implements Plugin<Project> {
         project.configurations {
             asakusaM3bpCommon {
                 description 'Common libraries of Asakusa DSL Compiler for M3BP'
+                extendsFrom project.configurations.asakusaLangCommon
                 exclude group: 'asm', module: 'asm'
             }
             asakusaM3bpCompiler {
                 description 'Full classpath of Asakusa DSL Compiler for M3BP'
-                extendsFrom project.configurations.compile
+                extendsFrom project.configurations.asakusaLangCompiler
                 extendsFrom project.configurations.asakusaM3bpCommon
             }
             asakusaM3bpTestkit {
                 description 'Asakusa DSL testkit classpath for M3BP'
+                extendsFrom project.configurations.asakusaLangTestkit
                 extendsFrom project.configurations.asakusaM3bpCommon
             }
         }
@@ -69,29 +72,11 @@ class AsakusaM3bpSdkBasePlugin implements Plugin<Project> {
             project.dependencies {
                 if (features.core) {
                     asakusaM3bpCommon "com.asakusafw.m3bp.compiler:asakusa-m3bp-compiler-core:${base.featureVersion}"
-                    asakusaM3bpCommon "com.asakusafw.lang.compiler:asakusa-compiler-cli:${base.langVersion}"
-                    asakusaM3bpCommon "com.asakusafw.lang.compiler:asakusa-compiler-extension-redirector:${base.langVersion}"
-                    asakusaM3bpCommon "com.asakusafw.lang.compiler:asakusa-compiler-extension-yaess:${base.langVersion}"
-                    asakusaM3bpCommon "com.asakusafw:simple-graph:${base.coreVersion}"
-                    asakusaM3bpCommon "com.asakusafw:java-dom:${base.coreVersion}"
-
-                    asakusaM3bpCompiler "com.asakusafw:asakusa-dsl-vocabulary:${base.coreVersion}"
-                    asakusaM3bpCompiler "com.asakusafw:asakusa-runtime:${base.coreVersion}"
-                    asakusaM3bpCompiler "com.asakusafw:asakusa-yaess-core:${base.coreVersion}"
-
                     if (features.directio) {
                         asakusaM3bpCommon "com.asakusafw.dag.compiler:asakusa-dag-compiler-extension-directio:${base.langVersion}"
-                        asakusaM3bpCompiler "com.asakusafw:asakusa-directio-vocabulary:${base.coreVersion}"
                     }
                     if (features.windgate) {
                         asakusaM3bpCommon "com.asakusafw.dag.compiler:asakusa-dag-compiler-extension-windgate:${base.langVersion}"
-                        asakusaM3bpCompiler "com.asakusafw:asakusa-windgate-vocabulary:${base.coreVersion}"
-                    }
-                    if (features.hive) {
-                        asakusaM3bpCommon "com.asakusafw.lang.compiler:asakusa-compiler-extension-hive:${base.langVersion}"
-                    }
-                    if (features.incubating) {
-                        asakusaM3bpCommon "com.asakusafw.lang.compiler:asakusa-compiler-extension-info:${base.langVersion}"
                     }
                 }
                 if (features.testing) {

--- a/gradle/src/test/groovy/com/asakusafw/m3bp/gradle/plugins/AsakusaUpgradeTest.groovy
+++ b/gradle/src/test/groovy/com/asakusafw/m3bp/gradle/plugins/AsakusaUpgradeTest.groovy
@@ -23,6 +23,7 @@ import org.junit.rules.TestName
 
 import com.asakusafw.gradle.plugins.AsakusafwBasePlugin
 import com.asakusafw.gradle.plugins.GradleTestkitHelper
+import com.asakusafw.lang.gradle.plugins.AsakusafwLangPlugin
 
 /**
  * Tests for cross Gradle versions compatibility.
@@ -89,6 +90,8 @@ class AsakusaUpgradeTest {
         Set<File> classpath = GradleTestkitHelper.toClasspath(
             AsakusafwBasePlugin,
             'META-INF/gradle-plugins/asakusafw-sdk.properties',
+            AsakusafwLangPlugin,
+            'META-INF/gradle-plugins/asakusafw-lang.properties',
             AsakusafwM3bpPlugin,
             'META-INF/gradle-plugins/asakusafw-m3bp.properties')
         String script = GradleTestkitHelper.getSimpleBuildScript(classpath, 'asakusafw-sdk', 'asakusafw-organizer', 'asakusafw-m3bp')

--- a/gradle/src/test/groovy/com/asakusafw/m3bp/gradle/plugins/internal/AsakusaM3bpOrganizerPluginTest.groovy
+++ b/gradle/src/test/groovy/com/asakusafw/m3bp/gradle/plugins/internal/AsakusaM3bpOrganizerPluginTest.groovy
@@ -24,6 +24,7 @@ import org.junit.runner.Description
 import org.junit.runners.model.Statement
 
 import com.asakusafw.gradle.plugins.AsakusafwOrganizerPluginConvention
+import com.asakusafw.lang.gradle.plugins.internal.AsakusaLangOrganizerPlugin
 import com.asakusafw.m3bp.gradle.plugins.AsakusafwOrganizerM3bpExtension
 
 /**
@@ -52,6 +53,7 @@ class AsakusaM3bpOrganizerPluginTest {
     void base() {
         assert project.plugins.hasPlugin('asakusafw-organizer') != null
         assert project.plugins.hasPlugin(AsakusaM3bpBasePlugin) != null
+        assert project.plugins.hasPlugin(AsakusaLangOrganizerPlugin) != null
     }
 
     /**

--- a/gradle/src/test/groovy/com/asakusafw/m3bp/gradle/plugins/internal/AsakusaM3bpSdkPluginTest.groovy
+++ b/gradle/src/test/groovy/com/asakusafw/m3bp/gradle/plugins/internal/AsakusaM3bpSdkPluginTest.groovy
@@ -32,6 +32,7 @@ import com.asakusafw.gradle.plugins.AsakusafwCompilerExtension
 import com.asakusafw.gradle.plugins.AsakusafwPluginConvention
 import com.asakusafw.gradle.tasks.AsakusaCompileTask
 import com.asakusafw.gradle.tasks.internal.ResolutionUtils
+import com.asakusafw.lang.gradle.plugins.internal.AsakusaLangSdkPlugin
 
 /**
  * Test for {@link AsakusaM3bpSdkPlugin}.
@@ -59,6 +60,7 @@ class AsakusaM3bpSdkPluginTest {
     void base() {
         assert project.plugins.hasPlugin('asakusafw-sdk') != null
         assert project.plugins.hasPlugin(AsakusaM3bpBasePlugin) != null
+        assert project.plugins.hasPlugin(AsakusaLangSdkPlugin) != null
     }
 
     /**


### PR DESCRIPTION
## Summary

This PR makes `asakusafw-m3bp` Gradle plug-in refer a new parent plug-in `asakusafw-lang` introduced asakusafw/asakusafw-compiler#142.

## Background, Problem or Goal of the patch

asakusafw/asakusafw-compiler#142 has introduced common Asakusa DSL compiler settings for this platform. It enables that introduce `tools/bin/info.sh` to deployment archives with using `asakusafw-m3bp`. This will also reduce impact on upstream structure changes.

## Design of the fix, or a new feature

N/A.

## Related Issue, Pull Request or Code

* asakusafw/asakusafw-compiler#142
