### PR TITLE
Suppress warnings of CMake policy CMP0069

### DIFF
--- a/bridge/runtime/src/main/native/CMakeLists.txt
+++ b/bridge/runtime/src/main/native/CMakeLists.txt
@@ -1,5 +1,9 @@
 cmake_minimum_required(VERSION 2.8)
 
+if (POLICY CMP0069)
+  cmake_policy(SET CMP0069 OLD)
+endif()
+
 project(m3bpjni CXX)
 
 find_package(JNI)

--- a/compiler/core/src/main/java/com/asakusafw/m3bp/compiler/core/extension/NativeValueComparatorParticipant.java
+++ b/compiler/core/src/main/java/com/asakusafw/m3bp/compiler/core/extension/NativeValueComparatorParticipant.java
@@ -160,6 +160,9 @@ public class NativeValueComparatorParticipant extends AbstractCompilerParticipan
 
     private static final String[] FILE_CMAKE_LISTS = {
             "cmake_minimum_required(VERSION 2.8)",
+            "if (POLICY CMP0069)",
+            "  cmake_policy(SET CMP0069 OLD)",
+            "endif()",
             "project(all CXX)",
             "set(CMAKE_SKIP_RPATH ON)",
             "file(GLOB NATIVE \"src/*.cpp\")",


### PR DESCRIPTION
## Summary
This PR fixes to suppress warnings of CMake policy CMP0069 on CMake 3.9 or higher version.

## Background, Problem or Goal of the patch
When executing  `m3bpCompileBatchapps` task on CMake 3.9 or higher the following warning log shows:
```
> Task :m3bpCompileBatchapps
...
17:32:57 INFO  compiling batch class: com.example.batch.SummarizeBatch
17:32:59 WARN  cmake: CMake Warning (dev) at CMakeLists.txt:6 (add_library):
17:32:59 WARN  cmake:   Policy CMP0069 is not set: INTERPROCEDURAL_OPTIMIZATION is enforced when
17:32:59 WARN  cmake:   enabled.  Run "cmake --help-policy CMP0069" for policy details.  Use the
17:32:59 WARN  cmake:   cmake_policy command to set the policy and suppress this warning.
17:32:59 WARN  cmake: 
17:32:59 WARN  cmake:   INTERPROCEDURAL_OPTIMIZATION property will be ignored for target
17:32:59 WARN  cmake:   'application'.
17:32:59 WARN  cmake: This warning is for project developers.  Use -Wno-dev to suppress it.
17:32:59 WARN  cmake: 
```

This problem is caused by CMake 3.9 introduced policy [CMP0069](https://cmake.org/cmake/help/v3.9/policy/CMP0069.html) and raise warnings when CMP0069 is not set in the corresponding version (See details for [CMP0069](https://cmake.org/cmake/help/v3.9/policy/CMP0069.html)).

## Design of the fix, or a new feature
This PR applies CMP0069 with `OLD` behavior.

Ideally we should use `NEW` behavior and use the `CheckIPOSupported` module to detect whether IPO is supported by the current compiler but it requires CMake 3.9 or higher version so we should just modify suppress this policy warnings for backward compatibility in Asakusa 0.10.x.

## Related Issue, Pull Request or Code
N/A.